### PR TITLE
feat(todo): add minimal personal todo module

### DIFF
--- a/adv/todo/advise.jso
+++ b/adv/todo/advise.jso
@@ -1,0 +1,267 @@
+{
+"#name"
+:
+{
+"todo"
+:
+null
+,
+"en"
+:
+"Personal todo list (task tracker) for x-cmd"
+,
+"cn"
+:
+"x-cmd 个人任务清单（任务跟踪器）"
+}
+,
+"#synopsis"
+:
+"x todo <subcmd> [options]"
+,
+"#desc"
+:
+{
+"en"
+:
+"Minimal personal todo list with an `active -> archived -> trash` state machine.\nPlain-text storage: one file per task under `$___X_CMD_ROOT_DATA/todo/<status>/<id>`.\nList output is TSV: `id \\t priority \\t created \\t status \\t name`.\n"
+,
+"cn"
+:
+"极简个人任务清单，状态机为 `active -> archived -> trash`。\n纯文本存储：每个任务一个文件，位于 `$___X_CMD_ROOT_DATA/todo/<status>/<id>`。\n列表输出为 TSV：`id \\t priority \\t created \\t status \\t name`。\n"
+}
+,
+"#tip"
+:
+[
+{
+"cn"
+:
+"list 默认只显示 active 任务；--all / --archived / --trash 可切换范围。\nrm 默认进 trash 可 restore 还原，--force 才物理删除。\n"
+,
+"en"
+:
+"`list` shows active tasks only by default; use --all / --archived / --trash.\n`rm` moves to trash (restorable) unless --force is given.\n"
+}
+]
+,
+"#tldr"
+:
+[
+{
+"cmd"
+:
+"x todo add buy milk"
+,
+"cn"
+:
+"添加任务"
+,
+"en"
+:
+"Add a task"
+}
+,
+{
+"cmd"
+:
+"x todo list --all"
+,
+"cn"
+:
+"列出全部任务（TSV）"
+,
+"en"
+:
+"List all tasks (TSV)"
+}
+,
+{
+"cmd"
+:
+"x todo done <id>"
+,
+"cn"
+:
+"完成任务（归档，reason=done）"
+,
+"en"
+:
+"Complete a task (archive with reason=done)"
+}
+,
+{
+"cmd"
+:
+"x todo archive <id> --reason no time"
+,
+"cn"
+:
+"归档任务并注明原因"
+,
+"en"
+:
+"Archive a task with a reason"
+}
+,
+{
+"cmd"
+:
+"x todo restore <id>"
+,
+"cn"
+:
+"从归档/回收站还原任务"
+,
+"en"
+:
+"Restore a task from archive/trash"
+}
+,
+{
+"cmd"
+:
+"x todo rm <id> --force"
+,
+"cn"
+:
+"物理删除任务"
+,
+"en"
+:
+"Permanently delete a task"
+}
+]
+,
+"add"
+:
+{
+"#desc"
+:
+{
+"en"
+:
+"Create a task: x todo add <name> [--priority low|normal|high] [--note <text>]. Prints the new task id."
+,
+"cn"
+:
+"创建任务：x todo add <name> [--priority low|normal|high] [--note <text>]。输出新任务 id。"
+}
+}
+,
+"list"
+:
+{
+"#desc"
+:
+{
+"en"
+:
+"List tasks as TSV (id/priority/created/status/name). Default: active only. --all/--archived/--trash change scope."
+,
+"cn"
+:
+"以 TSV 列出任务（id/priority/created/status/name）。默认仅 active；--all/--archived/--trash 切换范围。"
+}
+}
+,
+"done"
+:
+{
+"#desc"
+:
+{
+"en"
+:
+"Mark an active task as done: moves it to archived with reason=done."
+,
+"cn"
+:
+"将 active 任务标记为完成：移入 archived，reason=done。"
+}
+}
+,
+"archive"
+:
+{
+"#desc"
+:
+{
+"en"
+:
+"Archive an active task: x todo archive <id> [--reason <text>]."
+,
+"cn"
+:
+"归档 active 任务：x todo archive <id> [--reason <text>]。"
+}
+}
+,
+"restore"
+:
+{
+"#desc"
+:
+{
+"en"
+:
+"Move a task from archive/trash back to active."
+,
+"cn"
+:
+"将任务从归档/回收站还原到 active。"
+}
+}
+,
+"rm"
+:
+{
+"#desc"
+:
+{
+"en"
+:
+"Remove a task: default moves it to trash (restorable); --force deletes it."
+,
+"cn"
+:
+"删除任务：默认移入 trash（可还原）；--force 物理删除。"
+}
+}
+,
+"show"
+:
+{
+"#desc"
+:
+{
+"en"
+:
+"Show one task's full record: x todo show <id>."
+,
+"cn"
+:
+"查看单个任务的完整记录：x todo show <id>。"
+}
+}
+,
+"#other"
+:
+{
+"en"
+:
+{
+"More info:"
+:
+"https://github.com/x-cmd/x-cmd/tree/X/mod/todo"
+}
+,
+"cn"
+:
+{
+"更多信息："
+:
+"https://github.com/x-cmd/x-cmd/tree/X/mod/todo"
+}
+}
+}

--- a/mod/todo/SKILL.md
+++ b/mod/todo/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: x-todo
+description: |
+  Minimal personal todo list (task tracker) for x-cmd.
+  add/list/done/archive/restore/rm with an active -> archived -> trash
+  state machine, plain-text storage (one file per task).
+
+  **Dependency**: This is an x-cmd module. Install x-cmd first (see x-cmd skill for installation options).
+
+license: Apache-2.0
+compatibility: POSIX Shell
+
+metadata:
+  author: xuanyuanluoxue
+  version: "0.1.0"
+  category: x-cmd-extension
+  tags: [x-cmd, todo, task, productivity]
+---
+
+# x todo - Personal Todo List
+
+> Minimal personal todo list with an `active -> archived -> trash` state machine.
+
+---
+
+## Quick Start
+
+```bash
+# Add a task
+x todo add "buy milk"
+
+# Add with priority and note
+x todo add "ship v1" --priority high --note "blocked by review"
+
+# List active tasks (TSV: id / priority / created / status / name)
+x todo list
+
+# List everything
+x todo list --all
+
+# Complete / archive / restore / remove
+x todo done <id>
+x todo archive <id> --reason "no time"
+x todo restore <id>
+x todo rm <id>          # to trash
+x todo rm <id> --force  # delete for real
+```
+
+---
+
+## Features
+
+- **State machine**: `active -> archived -> trash`, each step is a file move
+- **Plain-text storage**: one file per task under `$___X_CMD_ROOT_DATA/todo/<status>/<id>`
+- **TSV output**: agent-friendly `id \t priority \t created \t status \t name` rows
+- **POSIX-only**: shell + awk, no external dependencies
+
+---
+
+## State Machine
+
+| Command | From | To |
+|---------|------|----|
+| `done <id>` | active | archived (reason=done) |
+| `archive <id>` | active | archived |
+| `restore <id>` | archived / trash | active |
+| `rm <id>` | any | trash |
+| `rm <id> --force` | any | deleted |
+
+---
+
+## Data Format
+
+Each task is a plain-text `key: value` file:
+
+```text
+name: buy milk
+priority: normal
+created: 1754123456
+finished: 1754123556
+reason: done
+note: optional
+```
+
+Storage layout:
+
+```text
+$___X_CMD_ROOT_DATA/todo/
+├── active/<id>
+├── archived/<id>
+└── trash/<id>
+```

--- a/mod/todo/latest
+++ b/mod/todo/latest
@@ -1,0 +1,12 @@
+# Author:       xuanyuanluoxue
+# shellcheck    shell=sh        disable=SC2039,SC1090,SC3043,SC2263
+
+# license:      AGPLv3
+
+xrc:mod:lib     todo   main
+
+___x_cmd_todo(){
+    ___x_cmd_todo___main "$@"
+}
+
+xrc setmain ___x_cmd_todo

--- a/mod/todo/lib/main
+++ b/mod/todo/lib/main
@@ -1,0 +1,212 @@
+# shellcheck shell=dash
+
+___x_cmd_todo___root(){
+    printf "%s\n" "${___X_CMD_ROOT_DATA:-"$HOME/.x-cmd.root/local/data"}/todo"
+}
+
+___x_cmd_todo___newid(){
+    printf "%s.%s\n" "$(date +%Y%m%d%H%M%S)" "$$"
+}
+
+___x_cmd_todo___main(){
+    [ "$#" -gt 0 ] || set -- --help
+
+    local op="$1"; shift
+    case "$op" in
+        -h|--help)  ___x_cmd_todo___help "$@" ; return 0 ;;
+        add|list|done|archive|restore|rm|show)
+                    "___x_cmd_todo_$op" "$@" ;;
+        *)          N=todo M="Unknown subcmd -> $op" log:ret:64 ;;
+    esac
+}
+
+___x_cmd_todo___help(){
+    cat <<EOF
+Usage: x todo <subcmd> [options]
+
+  add <name> [--priority low|normal|high] [--note <text>]  create a task
+  list [--all|--archived|--trash]                          list tasks (TSV)
+  done <id>         mark an active task as done (archive with reason=done)
+  archive <id> [--reason <text>]                           archive an active task
+  restore <id>      move a task from archive/trash back to active
+  rm <id> [--force] move a task to trash; --force deletes it
+  show <id>         show one task's full record
+
+State machine: active -> archived -> trash. Each task is one plain-text
+file under \$___X_CMD_ROOT_DATA/todo/<status>/<id>.
+EOF
+}
+
+___x_cmd_todo_add(){
+    local priority="normal" note=""
+    local name=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --priority)         priority="$2" ; arg:2:shift ;;
+            --note)             note="$2"     ; arg:2:shift ;;
+            --)                 shift ; break ;;
+            -*)                 N=todo M="Unknown option -> $1" log:ret:64 ;;
+            *)                  name="$name $1" ; shift ;;
+        esac
+    done
+    while [ $# -gt 0 ]; do
+        name="$name $1" ; shift
+    done
+    name="${name# }"
+
+    [ -n "$name" ] || { x:error "task name required" ; return 64 ; }
+
+    case "$priority" in
+        low|normal|high) ;;
+        *) N=todo M="Invalid priority -> $priority (low|normal|high)" log:ret:64 ;;
+    esac
+
+    local root; root="$(___x_cmd_todo___root)"
+    ___x_cmd mkdirp "$root/active"
+
+    local id; id="$(___x_cmd_todo___newid)"
+    {
+        printf "name: %s\n" "$name"
+        printf "priority: %s\n" "$priority"
+        printf "created: %s\n" "$(date +%s)"
+        [ -z "$note" ] || printf "note: %s\n" "$note"
+    } >"$root/active/$id"
+    printf "%s\n" "$id"
+}
+
+___x_cmd_todo_list(){
+    local scope="active"
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --all)      scope="all" ; shift ;;
+            --archived) scope="archived" ; shift ;;
+            --trash)    scope="trash" ; shift ;;
+            *)          N=todo M="Unknown option -> $1" log:ret:64 ;;
+        esac
+    done
+
+    local root; root="$(___x_cmd_todo___root)"
+    local d f
+    for d in active archived trash; do
+        case "$scope" in
+            all|"$d") ;;
+            *) continue ;;
+        esac
+        [ -d "$root/$d" ] || continue
+        for f in "$root/$d"/*; do
+            [ -f "$f" ] || continue
+            ___x_cmd_todo___print_row "$d" "$f"
+        done
+    done
+}
+
+___x_cmd_todo___print_row(){
+    local status="$1" file="$2" id
+    id="$(basename "$file")"
+    awk -v id="$id" -v status="$status" '
+        {
+            i = index($0, ": ");
+            if (i <= 0) next;
+            k = substr($0, 1, i - 1);
+            v = substr($0, i + 2);
+            if      (k == "name")     name     = v;
+            else if (k == "priority") priority = v;
+            else if (k == "created")  created  = v;
+        }
+        END { printf "%s\t%s\t%s\t%s\t%s\n", id, priority, created, status, name }
+    ' "$file"
+}
+
+___x_cmd_todo___move_to_archived(){
+    local id="$1" reason="$2"
+    local root; root="$(___x_cmd_todo___root)"
+
+    local src="$root/active/$id"
+    [ -f "$src" ] || { x:error "task not found or not active: $id" ; return 1 ; }
+
+    ___x_cmd mkdirp "$root/archived"
+    mv "$src" "$root/archived/$id"
+    local tmp="$root/archived/.$id.$$"
+    {
+        sed '/^finished: /d; /^reason: /d' "$root/archived/$id"
+        printf "finished: %s\n" "$(date +%s)"
+        printf "reason: %s\n" "$reason"
+    } >"$tmp"
+    mv "$tmp" "$root/archived/$id"
+}
+
+___x_cmd_todo_done(){
+    ___x_cmd_todo___move_to_archived "$1" "done"
+}
+
+___x_cmd_todo_archive(){
+    local reason="archived" id=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --reason)  reason="$2" ; arg:2:shift ;;
+            -*)        N=todo M="Unknown option -> $1" log:ret:64 ;;
+            *)         id="$1" ; shift ;;
+        esac
+    done
+    ___x_cmd_todo___move_to_archived "$id" "$reason"
+}
+
+___x_cmd_todo_restore(){
+    local id="$1"
+    local root; root="$(___x_cmd_todo___root)"
+
+    local src=""
+    [ -f "$root/trash/$id" ]    && src="$root/trash/$id"
+    [ -n "$src" ] || { [ -f "$root/archived/$id" ] && src="$root/archived/$id" ; }
+
+    [ -n "$src" ] || { x:error "task not found in archive/trash: $id" ; return 1 ; }
+
+    ___x_cmd mkdirp "$root/active"
+    sed '/^finished: /d; /^reason: /d' "$src" >"$root/active/$id"
+    rm -f "$src"
+}
+
+___x_cmd_todo_rm(){
+    local force=0 id=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --force) force=1 ; shift ;;
+            -*)      N=todo M="Unknown option -> $1" log:ret:64 ;;
+            *)       id="$1" ; shift ;;
+        esac
+    done
+
+    local root; root="$(___x_cmd_todo___root)"
+
+    local src="" d
+    for d in active archived trash; do
+        [ -f "$root/$d/$id" ] && { src="$root/$d/$id" ; break ; }
+    done
+
+    [ -n "$src" ] || { x:error "task not found: $id" ; return 1 ; }
+
+    if [ "$force" -eq 1 ]; then
+        rm -f "$src"
+    else
+        ___x_cmd mkdirp "$root/trash"
+        mv "$src" "$root/trash/$id"
+    fi
+}
+
+___x_cmd_todo_show(){
+    local id="$1"
+    local root; root="$(___x_cmd_todo___root)"
+
+    local src="" d
+    for d in active archived trash; do
+        [ -f "$root/$d/$id" ] && { src="$root/$d/$id" ; break ; }
+    done
+
+    [ -n "$src" ] || { x:error "task not found: $id" ; return 1 ; }
+
+    printf "id: %s\n" "$id"
+    printf "status: %s\n" "$d"
+    ___x_cmd rat "$src"
+}


### PR DESCRIPTION
## Summary

Adds a minimal personal todo list module (`x todo`) for x-cmd: a task tracker with an `active -> archived -> trash` state machine, plain-text storage (one file per task), and TSV output friendly to AI agents.

Related cooperation discussion: https://github.com/x-cmd/x-cmd/discussions/455

## Commands

| Command | Behavior |
|---|---|
| `x todo add <name> [--priority low\|normal\|high] [--note <text>]` | create a task (active) |
| `x todo list [--all\|--archived\|--trash]` | list tasks, TSV output |
| `x todo done <id>` | active -> archived (reason=done) |
| `x todo archive <id> [--reason <text>]` | active -> archived |
| `x todo restore <id>` | archived/trash -> active |
| `x todo rm <id> [--force]` | -> trash; `--force` deletes |
| `x todo show <id>` | show full record |

## Design

- Storage: `$___X_CMD_ROOT_DATA/todo/<status>/<id>`, one plain-text `key: value` file per task
- State machine = file moves between `active/`, `archived/`, `trash/`
- Pure POSIX shell + awk (shell=dash), no external dependencies
- Files: `mod/todo/latest`, `mod/todo/lib/main`, `mod/todo/SKILL.md`, `adv/todo/advise.jso`

## Verification

- 17 BDD scenarios (add/list/done/archive/restore/rm/show, error paths, exit codes) all pass under bash and dash in WSL
- Unknown subcommand -> exit 64; unknown id / illegal transition -> exit 1