### PR TITLE
feat: add OrcaRouter API-key and PKCE login

### DIFF
--- a/mod/agent/lib/data/agent_provider_full_en
+++ b/mod/agent/lib/data/agent_provider_full_en
@@ -1,5 +1,6 @@
 claude                  # Anthropic Claude Code (OAuth login, uses ~/.claude/settings.json)
 claude-openrouter       # Claude Code + OpenRouter backend (API key)
+claude-orcarouter       # Claude Code + OrcaRouter backend (API key or PKCE login)
 claude-deepseek         # Claude Code + DeepSeek backend (API key)
 claude-kimi             # Claude Code + Moonshot Kimi backend (API key)
 claude-moonshot         # Claude Code + Moonshot AI backend (API key)

--- a/mod/agent/lib/data/agent_provider_full_zh
+++ b/mod/agent/lib/data/agent_provider_full_zh
@@ -1,5 +1,6 @@
 claude                  # Anthropic Claude Code（OAuth 登录，使用 ~/.claude/settings.json）
 claude-openrouter       # Claude Code + OpenRouter 后端（API key）
+claude-orcarouter       # Claude Code + OrcaRouter 后端（API key 或 PKCE 登录）
 claude-deepseek         # Claude Code + DeepSeek 后端（API key）
 claude-kimi             # Claude Code + Moonshot Kimi 后端（API key）
 claude-moonshot         # Claude Code + Moonshot AI 后端（API key）

--- a/mod/agent/lib/data/claude_provider_minimal_en
+++ b/mod/agent/lib/data/claude_provider_minimal_en
@@ -1,5 +1,6 @@
 claude                  # Anthropic official (OAuth login, uses ~/.claude/settings.json)
 openrouter              # OpenRouter (API key)
+orcarouter              # OrcaRouter (API key or PKCE login)
 deepseek                # DeepSeek (API key)
 kimi                    # Moonshot Kimi (API key)
 moonshot                # Moonshot AI (API key)

--- a/mod/agent/lib/data/claude_provider_minimal_zh
+++ b/mod/agent/lib/data/claude_provider_minimal_zh
@@ -1,5 +1,6 @@
 claude                  # Anthropic 官方（OAuth 登录，使用 ~/.claude/settings.json）
 openrouter              # OpenRouter（API key）
+orcarouter              # OrcaRouter（API key 或 PKCE 登录）
 deepseek                # DeepSeek（API key）
 kimi                    # Moonshot Kimi（API key）
 moonshot                # Moonshot AI（API key）

--- a/mod/chat/lib/advise
+++ b/mod/chat/lib/advise
@@ -20,6 +20,7 @@ ___x_cmd_chat_advise___model_list(){
             *\ zhipu\ *|*@glm*)             provider=zhipu      ;;
             *\ siliconflow\ *|*@sili*)      provider=siliconflow ;;
             *\ openrouter\ *|*@or*)         provider=openrouter ;;
+            *\ orcarouter\ *|*@orc*)        provider=orcarouter ;;
             *\ lms\ *|*@lms*)               provider=lms        ;;
             *\ minimax\ *|*\ mm\ *|*@minimax*|*@mm*)
                                             provider=minimax    ;;

--- a/mod/chat/lib/cfg
+++ b/mod/chat/lib/cfg
@@ -30,7 +30,7 @@ ___x_cmd_chat_init(){
     ___x_cmd_chat_cfg___invoke --init --ctrl_exit_strategy          \
         provider    "Select the AI provider"                        \
                     "${cur_provider:-auto}"                         \
-                        '='    auto gemini openai mistral deepseek grok gh moonshot zhipu siliconflow openrouter minimax ollama llmf lms --   \
+                        '='    auto gemini openai mistral deepseek grok gh moonshot zhipu siliconflow openrouter orcarouter minimax ollama llmf lms --   \
         stream      "Use streaming response"                        \
                     "${cur_stream:-"false"}"    '=' false true --   \
         reasoning   "Show reasoning process"                        \
@@ -49,7 +49,7 @@ ___x_cmd_chat_init(){
     fi
 
     case "$cur_provider" in
-        openai|gemini|mistral|deepseek|grok|gh|moonshot|doubao|zhipu|siliconflow|openrouter|minimax|ollama|lms)
+        openai|gemini|mistral|deepseek|grok|gh|moonshot|doubao|zhipu|siliconflow|openrouter|orcarouter|minimax|ollama|lms)
                 chat:info "x $cur_provider init"
                 ___x_cmd "$cur_provider" init  ;;
         llmf|hub)   ;;

--- a/mod/chat/lib/provider
+++ b/mod/chat/lib/provider
@@ -46,19 +46,19 @@ ___x_cmd_chat_provider_get_(){
     local cur_provider=""
     ___x_cmd_chat_cur cur_provider:=provider 2>/dev/null
     cur_provider="${cur_provider:-gemini}"
-    ___x_cmd_chat_provider_pick_ "$cur_provider" gemini openai mistral deepseek grok gh moonshot doubao zhipu siliconflow openrouter minimax ollama llmf lms
+    ___x_cmd_chat_provider_pick_ "$cur_provider" gemini openai mistral deepseek grok gh moonshot doubao zhipu siliconflow openrouter orcarouter minimax ollama llmf lms
 }
 
 ___x_cmd_chat_provider_ls(){
-    printf "%s\n" openai gemini mistral deepseek grok gh moonshot doubao zhipu siliconflow openrouter minimax ollama llmf lms
+    printf "%s\n" openai gemini mistral deepseek grok gh moonshot doubao zhipu siliconflow openrouter orcarouter minimax ollama llmf lms
 }
 
 ___x_cmd_chat_provider___validate(){
     local provider="$1"
     case "$provider" in
-        openai|gemini|mistral|deepseek|grok|gh|moonshot|doubao|zhipu|siliconflow|openrouter|minimax|hub|ollama|llmf|lms) ;;
+        openai|gemini|mistral|deepseek|grok|gh|moonshot|doubao|zhipu|siliconflow|openrouter|orcarouter|minimax|hub|ollama|llmf|lms) ;;
         *)
-            N=chat M="Provider must be [openai|gemini|mistral|deepseek|grok|gh|moonshot|doubao|zhipu|siliconflow|openrouter|minimax|hub|ollama|llmf|lms]" log:ret:64
+            N=chat M="Provider must be [openai|gemini|mistral|deepseek|grok|gh|moonshot|doubao|zhipu|siliconflow|openrouter|orcarouter|minimax|hub|ollama|llmf|lms]" log:ret:64
             ;;
     esac
 }

--- a/mod/chat/lib/util
+++ b/mod/chat/lib/util
@@ -51,6 +51,7 @@ ___x_cmd_chat_send(){
             kimi)   cur_provider=moonshot ;;
             sili)   cur_provider=siliconflow ;;
             or)     cur_provider=openrouter ;;
+            orc)    cur_provider=orcarouter ;;
             glm)    cur_provider=zhipu ;;
             *)      return 1 ;;
         esac
@@ -121,7 +122,7 @@ ___x_cmd_chat_model_ls(){
                 ___x_cmd "$provider" model ls --fast ;;
             ollama)
                 ___x_cmd ollama ls | ___x_cmd_cmds awk -v FS=, 'NR>1{ print $1; }' ;;
-            mistral|moonshot|siliconflow|openrouter)
+            mistral|moonshot|siliconflow|openrouter|orcarouter)
                 ___x_cmd "$provider" model ls --csv | ___x_cmd_cmds awk -v FS=, 'NR>1{ print $1; }' ;;
             llmf)
                 xrc llmf;   ___x_cmd_llmf_advise___ls_model ;;

--- a/mod/claude/lib/main
+++ b/mod/claude/lib/main
@@ -43,6 +43,7 @@ ___x_cmd_claude___main(){
         # c|container)        ___x_cmd_claude_container       "$@" ;;
 
         or|openrouter)      ___x_cmd_claude_openrouter      "$@" ;;
+        orc|orcarouter)     ___x_cmd_claude_orcarouter     "$@" ;;
         ds|deepseek)        ___x_cmd_claude_ds              "$@" ;;
         kimi)               ___x_cmd_claude_kimi            "$@" ;;
         moonshot)           ___x_cmd_claude_moonshot        "$@" ;;

--- a/mod/claude/lib/other/_index
+++ b/mod/claude/lib/other/_index
@@ -12,7 +12,7 @@ local x_nonessential_traffic=1
 local x_effortlevel=auto
 '
 
-xrc:mod:lib     claude      other/ds    other/kimi    other/zhipu    other/sili    other/doubao    other/openrouter  other/mthreads  other/minimax  other/ali  other/baidu  other/tencent other/moonshot
+xrc:mod:lib     claude      other/ds    other/kimi    other/zhipu    other/sili    other/doubao    other/openrouter  other/orcarouter  other/mthreads  other/minimax  other/ali  other/baidu  other/tencent other/moonshot
 
 ___x_cmd_claude_other___use(){
     local provider="$1"

--- a/mod/claude/lib/other/orcarouter
+++ b/mod/claude/lib/other/orcarouter
@@ -1,0 +1,61 @@
+# shellcheck shell=dash
+
+# Run Claude Code against the OrcaRouter gateway.
+#
+# OrcaRouter speaks the Anthropic wire format as well as the OpenAI one (the
+# catalogue advertises `anthropic` in supported_endpoint_types for the Anthropic
+# family), so Claude Code can be pointed at the inference origin directly. The
+# shared adapter appends /v1, so x_url carries the bare origin.
+
+___x_cmd_claude_orcarouter(){
+    local op="$1"
+    case "$op" in
+        -h|--help)      ___x_cmd help -m claude orcarouter; return 0 ;;
+        --cfg)          ___x_cmd orcarouter "$@";     return $? ;;
+        --)             shift ;;
+    esac
+
+    claude:provider:fetch:init
+    ___x_cmd_claude_orcarouter___fetch_   || return $?
+
+    ANTHROPIC_API_KEY="" API_TIMEOUT_MS="$x_timeout"        \
+        ___x_cmd_claude_other___use     orcarouter                \
+        "$x_url" "$x_apikey" "$x_model" "$x_fastmodel" "$x_nonessential_traffic" "$x_effortlevel" "$@"
+}
+
+___x_cmd_claude_orcarouter___fetch_(){
+    local model=""
+    local apikey=""
+    local endpoint=
+
+    ___x_cmd orcarouter --cur apikey:=  model:=  endpoint:= 2>/dev/null
+
+    [ -n "$apikey" ] || {
+        claude:warn \
+            --tip1 'x orcarouter connect'                            \
+            --tip2 'x orcarouter --cfg apikey=<YOUR-API-KEY>'        \
+            "Please set up an OrcaRouter credential."
+
+        if ___x_cmd_runmode_allow_manual; then
+            ___x_cmd orcarouter --cfg || return $?
+            ___x_cmd orcarouter --cur apikey:=    endpoint:= 2>/dev/null
+        fi
+        [ -n "$apikey" ] || N=claude M="Failed to retrieve the OrcaRouter credential. Please check your configuration." log:ret:1
+    }
+
+    endpoint="$(___x_cmd_orcarouter_util_api_base)"
+    ___x_cmd_orcarouter_util_require_origin "inference" "$endpoint" || return 1
+
+    x_url="$endpoint"
+    x_apikey="$apikey"
+
+    # Claude Code is an Anthropic-format client, so default to a model that
+    # advertises the `anthropic` endpoint type rather than an OpenAI-only one.
+    x_model="${model}"
+    [ -n "$x_model" ] || x_model="anthropic/claude-opus-4.8"
+
+    x_fastmodel="${x_model}"
+    x_effortlevel=auto
+
+    x_timeout="${API_TIMEOUT_MS:-"3000000"}"
+}

--- a/mod/claude/lib/router/setup
+++ b/mod/claude/lib/router/setup
@@ -9,7 +9,7 @@ ___x_cmd_claude_router_setup(){
     while [ $# -gt 0 ]; do
         case "$1" in
             -h|--help)              ___x_cmd help -m claude router setup ; return 0 ;;
-            --gemini|--openai|--deepseek|--openrouter)
+            --gemini|--openai|--deepseek|--openrouter|--orcarouter)
                                     provider="${1#*--}";
                                     [ $# -ge 2 ] || N=claude M="Please provide argument after $1" log:ret:64 ;
                                     model="$2";       shift 2 ;;
@@ -96,6 +96,14 @@ ___x_cmd_claude_router_setup___templates_provider(){
             transformer='{
               "use": ["openrouter"]
             }'
+            ;;
+        orcarouter)
+            # OrcaRouter is a plain OpenAI-compatible gateway, so no provider
+            # specific transformer is applied here. The base URL carries the
+            # inference origin and its /v1 prefix; the auth origin is a
+            # different host and is never used for inference.
+            api_base_url="https://api.orcarouter.ai/v1/chat/completions"
+            transformer='{}'
             ;;
         *)
             N=claude M="The ${name} configuration template is not currently supported." log:ret:1 ;;

--- a/mod/openai/lib/chat/_index
+++ b/mod/openai/lib/chat/_index
@@ -20,7 +20,7 @@ ___x_cmd_openai_chat(){
 ___x_cmd_openai_chat_provider___validate(){
     local provider="$1"
     case "$provider" in
-        openai|mistral|deepseek|grok|gh|moonshot|doubao|zhipu|siliconflow|openrouter|minimax|hub|ollama|llmf|lms) return 0 ;;
+        openai|mistral|deepseek|grok|gh|moonshot|doubao|zhipu|siliconflow|openrouter|orcarouter|minimax|hub|ollama|llmf|lms) return 0 ;;
         *)
             N=openai M="Provider API format must be OpenAI-compatible" log:ret:64
             ;;

--- a/mod/orcarouter/README.md
+++ b/mod/orcarouter/README.md
@@ -1,0 +1,110 @@
+# `x orcarouter`
+
+[OrcaRouter](https://www.orcarouter.ai) as a first-class x-cmd model provider,
+with two independent ways to authenticate.
+
+## Origins
+
+| Purpose | Default |
+| --- | --- |
+| Authentication + code exchange | `https://www.orcarouter.ai` |
+| Inference + model catalogue | `https://api.orcarouter.ai/v1` |
+
+These are different hosts and are never derived from one another. The relay is
+on `api.orcarouter.ai/v1`; the auth endpoints are on `www.orcarouter.ai/api/v1/auth`.
+`https://api.orcarouter.ai/v1/auth/keys` is a 404.
+
+Overrides, explicit first:
+
+1. the module config (`endpoint`, `authbase`)
+2. `ORCA_API_BASE_URL` / `ORCA_AUTH_BASE_URL`
+3. `ORCA_BASE_URL` (shared, for single-origin self-hosted deployments)
+4. the public defaults above
+
+HTTPS is required for remote origins; plain HTTP is accepted only for loopback.
+
+## Authentication
+
+### API key
+
+```sh
+x orcarouter --cfg apikey=<sk-orca-...>
+```
+
+Or export `ORCAROUTER_API_KEY` / `ORCA_KEY`. Keys are created in the
+[OrcaRouter console](https://www.orcarouter.ai/console/keys).
+
+### Account login (OAuth 2.0 + PKCE)
+
+```sh
+x orcarouter connect
+```
+
+Opens the consent screen and accepts the code it displays (out-of-band flow),
+then exchanges it for an OrcaRouter API key bound to your own account. No
+client secret and no pre-registered redirect URI are involved: PKCE binds the
+authorization code to this process.
+
+The returned key is **durable, not refreshable**. It is stored in x-cmd's normal
+config store and reused on every later run; nothing refreshes it and nothing
+re-authorizes on launch (OrcaRouter caps PKCE-issued keys at 10 per user per
+24 hours). Re-run with `--force` to mint a new one, or:
+
+```sh
+x orcarouter disconnect
+```
+
+A `401` from the relay is terminal for the credential generation that made the
+request: that exact account generation is marked as needing reauthentication
+and the client is told to sign in again. Revoke the app at any time from
+<https://www.orcarouter.ai/console/authorized-apps>.
+
+Both paths produce the same credential record, so `x chat`, the model catalogue,
+`x claude orcarouter` and `x agent` do not care which one you used.
+
+```sh
+x orcarouter credits     # show the credential's source, generation and state
+```
+
+## Models
+
+```sh
+x orcarouter model ls              # interactive browser
+x orcarouter model ls --csv        # for scripting
+x orcarouter model ls --vision     # chat models that declare image input
+x orcarouter model set <model-id>
+```
+
+The list is read live from `GET <inference origin>/v1/models` with your own key,
+so it reflects what your workspace can actually call. Add `?capability=` to
+filter by capability:
+
+| Flag | Catalogue query | Rule applied |
+| --- | --- | --- |
+| *(default)* / `--chat` | `?capability=chat` | speaks `openai`/`anthropic`/`gemini`/`openai-response`, and is not an image/video/rerank-only model |
+| `--vision`, `--audio`, `--file` | `?capability=chat` | the above, plus `architecture.input_modalities` must declare that modality — models that declare nothing are excluded |
+| `--embedding` | `?capability=embedding` | `embeddings` endpoint |
+| `--image` | `?capability=image` | `image-generation` endpoint |
+| `--video` | *(strict match)* | `openai-video` endpoint |
+| `--rerank` | *(strict match)* | `jina-rerank` endpoint |
+
+Capabilities come from catalogue metadata only, never from a model's name.
+Model IDs keep their `vendor/model` namespace.
+
+If live discovery fails, a small verified fallback catalogue is shown and
+explicitly labelled as degraded; it is never mixed into a successful live
+result.
+
+## Chat
+
+```sh
+x orcarouter chat request "Explain sed in one paragraph"
+x chat --provider orcarouter "..."      # or: @orc "..."
+x claude orcarouter                     # Claude Code against the gateway
+```
+
+## Related
+
+- `<https://www.orcarouter.ai>` — console, API keys, authorized apps
+- `<https://api.orcarouter.ai/v1>` — OpenAI-compatible relay
+- Discord: <https://discord.gg/YEubt8enRA> · X: <https://x.com/OrcaRouter>

--- a/mod/orcarouter/latest
+++ b/mod/orcarouter/latest
@@ -1,0 +1,12 @@
+# Author:       OrcaRouter integration
+# shellcheck    shell=sh        disable=SC2039,SC1090,SC3043,SC2263
+
+# license:      AGPLv3
+
+xrc:mod:lib     orcarouter   main
+
+___x_cmd_orcarouter(){
+    ___x_cmd_orcarouter___main "$@"
+}
+
+xrc setmain ___x_cmd_orcarouter

--- a/mod/orcarouter/lib/cfg
+++ b/mod/orcarouter/lib/cfg
@@ -1,0 +1,119 @@
+# shellcheck shell=dash disable=SC2034
+
+xrc cfgy
+___x_cmd_orcarouter_cfg(){
+    [ "$#" -gt 0 ] || {
+        ___x_cmd_orcarouter_init
+        return
+    }
+
+    local op="$1"; shift
+    case "$op" in
+        -h|--help)      ___x_cmd help -m orcarouter --cfg ;;
+        --minimal-init) ___x_cmd_orcarouter_minimal_init "$@" ;;
+        apikey=*)       ___x_cmd_orcarouter_cfg___invoke "$op" "$@"
+                        # The pasted-key path is the API-key adapter of the
+                        # credential seam. Record provenance + a fresh
+                        # generation so a later 401 can be attributed exactly.
+                        ! ___x_cmd_orcarouter_has_apikey 2>/dev/null >&2 || {
+                            local k=; k="$(___x_cmd_orcarouter_cred_key_raw 2>/dev/null)"
+                            ___x_cmd_orcarouter_cred_apply "$k" apikey >/dev/null 2>&1
+                            ___x_cmd chat --setalias orcarouter orc
+                        }
+                        ;;
+        def_)           ___x_cmd_orcarouter_def_ "$@" ;;
+        *)              ___x_cmd_orcarouter_cfg___invoke "$op" "$@" ;;
+    esac
+}
+
+___x_cmd_orcarouter_def_(){
+    local op="$1";
+    case "$op" in
+        model)          x_="$___X_CMD_ORCAROUTER_DEFAULT_FIRST_MODEL" ;;
+        endpoint)       x_="$___X_CMD_ORCAROUTER_DEFAULT_ENDPOINT" ;;
+        authbase)  x_="$___X_CMD_ORCAROUTER_DEFAULT_AUTH_ENDPOINT" ;;
+        *) ;;
+    esac
+}
+
+___x_cmd_orcarouter_cur(){
+    local X_help_cmd=; X_help_cmd='___x_cmd help -m orcarouter --cur' help:arg:parse
+    ___x_cmd_orcarouter_cfg --current "$@"
+}
+
+___x_cmd_orcarouter_minimal_init(){
+    local cur_apikey=""
+    if [ -f "$(___x_cmd_orcarouter_cur --get config)" ]; then
+        ___x_cmd_orcarouter_cur cur_apikey:=apikey
+    fi
+
+    orcarouter:info "To get an OrcaRouter API key -> $___X_CMD_ORCAROUTER_KEYS_URL"
+    orcarouter:info "Or sign in instead: x orcarouter connect"
+
+    ___x_cmd_orcarouter_cfg___invoke --init ${cur_apikey:+"--ctrl_exit_strategy"} \
+        apikey      "Set up the OrcaRouter API key"                           \
+                    "$cur_apikey"   '=~*' "^[A-Za-z0-9._-]+$"
+
+    ___x_cmd_orcarouter_has_apikey 2>/dev/null >&2
+}
+
+___x_cmd_orcarouter_init(){
+    local cur_apikey=; local cur_model=; local cur_maxtoken=; local cur_temperature=;
+    local cur_proxy=; local cur_endpoint=; local cur_authbase=; local cur_scope=;
+
+    if [ -f "$(___x_cmd_orcarouter_cur --get config)" ]; then
+        ___x_cmd_orcarouter_cur cur_apikey:=apikey cur_model:=model cur_maxtoken:=maxtoken \
+            cur_temperature:=temperature cur_proxy:=proxy cur_endpoint:=endpoint \
+            cur_authbase:=authbase cur_scope:=scope 2>/dev/null
+    fi
+
+    orcarouter:info "To get an OrcaRouter API key -> $___X_CMD_ORCAROUTER_KEYS_URL"
+    orcarouter:info "Or sign in with your account -> x orcarouter connect"
+
+    ___x_cmd_orcarouter_cfg___invoke --init ${cur_apikey:+"--ctrl_exit_strategy"} \
+        apikey      "Set up the OrcaRouter API key"                           \
+                    "$cur_apikey"   '=~*' "^[A-Za-z0-9._-]+$" --               \
+        model       "Set up the OrcaRouter model"                             \
+                    "${cur_model:-"$___X_CMD_ORCAROUTER_DEFAULT_FIRST_MODEL"}" \
+                    '=' openai/gpt-5.5 anthropic/claude-opus-4.8 google/gemini-3.5-flash deepseek/deepseek-v4-pro orcarouter/auto -- \
+        maxtoken    "Set up the OrcaRouter maxtoken"                          \
+                    "${cur_maxtoken:-2048}" --         \
+        temperature "Set up the OrcaRouter temperature"                       \
+                    "${cur_temperature:-"1.0"}" --                              \
+        proxy       "Set up the network proxy for API requests (optional)"    \
+                    "$cur_proxy" '=~'    "^([a-z0-9]+://)?[0-9.:]+$" --         \
+        endpoint    "Set up the inference endpoint (optional)"                \
+                    "${cur_endpoint:-"$___X_CMD_ORCAROUTER_DEFAULT_ENDPOINT"}" -- \
+        authbase "Set up the authentication endpoint (optional)"         \
+                    "${cur_authbase:-"$___X_CMD_ORCAROUTER_DEFAULT_AUTH_ENDPOINT"}" -- \
+        scope       "Set up the requested scope (api or connector)"           \
+                    "${cur_scope:-api}" '=' api connector || return $?
+
+    ! ___x_cmd_orcarouter_has_apikey 2>/dev/null >&2 || ___x_cmd chat --setalias orcarouter orc
+}
+
+___x_cmd_orcarouter_has_apikey(){
+    local apikey=
+    apikey="$(___x_cmd_orcarouter_cred_key_raw 2>/dev/null)"
+    [ -n "$apikey" ] || {
+        orcarouter:error "Please set up your OrcaRouter API key first ==> 'x orcarouter --cfg apikey=<your api key>'"
+        orcarouter:warn "Get an API key from ==>  $___X_CMD_ORCAROUTER_KEYS_URL"
+        orcarouter:warn "Or sign in with your account ==>  x orcarouter connect"
+        return 1
+    }
+}
+
+# Config fields that carry credential lifecycle state as well as user options.
+# apikey is masked on read-back by cfgy ('=~*'), so it is never echoed.
+___X_CMD_ORCAROUTER_CFG_VARLIST="apikey,model,maxtoken,temperature,seed,proxy,endpoint,authbase,scope,appname,credsrc,credgen,needsreauth,reauthgen"
+___x_cmd_orcarouter_cfg___invoke(){
+    ___X_CMD_ORCAROUTER_CFG_DATA_FALLBACK_apikey="${ORCAROUTER_API_KEY}"
+
+    ___x_cmd_cfgy_obj   \
+        --prefix            ___X_CMD_ORCAROUTER_CFG_DATA                \
+        --default-config    "${___X_CMD_ROOT_CFG}/orcarouter/X.cfg.yml" \
+        --current-config    "${___X_CMD_ORCAROUTER_LOCAL_CONFIG}"       \
+        --current-profile   "${___X_CMD_ORCAROUTER_LOCAL_PROFILE}"      \
+        --varlist           "$___X_CMD_ORCAROUTER_CFG_VARLIST"          \
+        "$@"
+}

--- a/mod/orcarouter/lib/chat/_index
+++ b/mod/orcarouter/lib/chat/_index
@@ -1,0 +1,37 @@
+# shellcheck shell=dash
+
+___x_cmd_orcarouter_chat(){
+    local X_help_cmd='___x_cmd help -m orcarouter chat'; help:arg-null:parse
+    local op="$1";
+    case "$op" in
+        request|exec)
+            shift; ___x_cmd_orcarouter_chat_"$op" "$@" ;;
+        *)  N=orcarouter M="Not support such [subcmd=$op]" log:ret:64
+    esac
+}
+
+___x_cmd_orcarouter_chat_request(){
+    local X_help_cmd='___x_cmd help -m orcarouter chat request'; help:arg:parse
+    ___x_cmd chat --exec --provider orcarouter "$@"
+}
+
+___x_cmd_orcarouter_chat_exec(){
+    # The shared OpenAI adapter appends /v1/chat/completions to this value, so
+    # it must be the bare inference origin. ___X_CMD_OPENAI_CHAT_ACTUAL_URL_NOT_V1
+    # is deliberately left unset: OrcaRouter is served from /v1.
+    local api_base=""; api_base="$(___x_cmd_orcarouter_util_api_base)"
+    ___x_cmd_orcarouter_util_require_origin "inference" "$api_base" || return 1
+
+    ___X_CMD_OPENAI_CHAT_ACTUAL_PROVIDER='orcarouter'                     \
+    ___X_CMD_OPENAI_CHAT_ACTUAL_PROVIDER_NAME='OrcaRouter'                \
+    ___X_CMD_OPENAI_CHAT_ACTUAL_ENDPOINT="$api_base"                      \
+    ___x_cmd openai chat exec "$@"
+}
+
+# A durable OrcaRouter key is not a refresh token: there is no refresh grant to
+# run and none is attempted. A relay 401 means the key was revoked, so the exact
+# credential generation that made the request is marked for reauthentication
+# and the user is told how to sign in again.
+___x_cmd_orcarouter_chat_handle_401(){
+    ___x_cmd_orcarouter_cred_handle_401 "$1"
+}

--- a/mod/orcarouter/lib/connect
+++ b/mod/orcarouter/lib/connect
@@ -1,0 +1,281 @@
+# shellcheck shell=dash
+
+# OAuth 2.0 + PKCE account login for OrcaRouter -- the PKCE adapter of the
+# credential seam in mod/orcarouter/lib/cred.
+#
+# Flow B (out-of-band code), per the OrcaRouter integration guide.
+#
+# Why B and not A (loopback redirect) or C (device grant):
+#   x-cmd is a portable shell library that runs wherever the user's shell runs
+#   -- a login shell, an SSH session, a container, a CI runner. It ships no
+#   HTTP listener primitive and cannot assume nc/socat exists, so Flow A's
+#   "listen on 127.0.0.1:<port>" is not uniformly available. Flow B needs no
+#   listening socket and no pre-registered redirect URI, and it degrades
+#   gracefully: on a machine with no browser the user simply opens the printed
+#   URL elsewhere and pastes the code back. Flow C is an additional capability
+#   and is deliberately not implemented here.
+#
+# PKCE properties enforced below:
+#   * verifier and state are drawn fresh from the platform CSPRNG per attempt;
+#   * challenge is base64url(sha256(verifier)) with no padding, method S256;
+#   * the verifier never leaves this process except in the exchange request
+#     body -- it is not in the authorize URL, not in a log, not in an error;
+#   * the code is single-use with a 10 minute TTL, so the attempt is bounded.
+
+___x_cmd_orcarouter_connect(){
+    local X_help_cmd='___x_cmd help -m orcarouter connect'; help:arg:parse
+
+    local force=0
+    case "$1" in
+        --force|-f)     force=1; shift ;;
+    esac
+
+    ___x_cmd_orcarouter_connect___run "$force" "$@"
+}
+
+___x_cmd_orcarouter_connect___run(){
+    local force="${1:-0}"
+
+    # A PKCE-issued key is durable: reuse it until OrcaRouter revokes it.
+    # Re-authorizing on every launch would burn the 10 keys/user/24h budget and
+    # lock the user out. --force is the explicit way to mint a new one.
+    if [ "$force" != "1" ] && [ -n "$(___x_cmd_orcarouter_cred_key_raw)" ] \
+        && ! ___x_cmd_orcarouter_cred_needs_reauth; then
+        orcarouter:info "An OrcaRouter credential is already stored; reusing it."
+        orcarouter:info "Run 'x orcarouter connect --force' to authorize again,"
+        orcarouter:info "or 'x orcarouter disconnect' to remove it first."
+        return 0
+    fi
+
+    local auth_base=""; auth_base="$(___x_cmd_orcarouter_util_auth_base)"
+    ___x_cmd_orcarouter_util_require_origin "authentication" "$auth_base" || return 1
+
+    local scope=""; ___x_cmd_orcarouter_cur scope:= 2>/dev/null
+    scope="${scope:-api}"
+    case "$scope" in
+        api|connector) ;;
+        *)  orcarouter:error "Unsupported scope [$scope]: OrcaRouter accepts 'api' or 'connector'."
+            return 64 ;;
+    esac
+
+    # 1. Fresh verifier + state + S256 challenge, from the CSPRNG.
+    local verifier=""; local challenge=""; local state=""
+    verifier="$(___x_cmd_orcarouter_util_rand_b64url 32)" || {
+        orcarouter:error "Could not read from a cryptographic random source."
+        return 1
+    }
+    [ -n "$verifier" ] || { orcarouter:error "Empty PKCE verifier generated."; return 1; }
+    challenge="$(___x_cmd_orcarouter_util_sha256_b64url "$verifier")" || {
+        orcarouter:error "Could not compute the S256 code challenge."
+        return 1
+    }
+    state="$(___x_cmd_orcarouter_util_rand_b64url 16)"
+
+    # Record the attempt. The verifier is written 0600 and removed on every
+    # terminal path; it is never echoed.
+    local attempt_dir=""; local attempt_file=""
+    attempt_dir="$(___x_cmd_orcarouter_util_attempt_dir)"
+    attempt_file="${attempt_dir}/attempt.$$"
+    ( umask 077; printf "%s\n%s\n%s\n" "$verifier" "$state" "$(___x_cmd_orcarouter_util_now)" > "$attempt_file" ) 2>/dev/null
+
+    ___x_cmd_orcarouter_connect___cleanup(){
+        [ -n "$attempt_file" ] && ___x_cmd rmrf "$attempt_file" 2>/dev/null
+    }
+    trap '___x_cmd_orcarouter_connect___cleanup' EXIT HUP INT TERM
+
+    # 2. Authorize URL. callback_url=oob is asked for explicitly; S256 is
+    #    mandatory for a code a human can read off a screen.
+    local url=""
+    url="${auth_base}${___X_CMD_ORCAROUTER_AUTHORIZE_PATH}"
+    url="${url}?callback_url=oob"
+    url="${url}&code_challenge=${challenge}"
+    url="${url}&code_challenge_method=S256"
+    url="${url}&state=${state}"
+    url="${url}&app_name=$(___x_cmd_orcarouter_connect___urlencode "$___X_CMD_ORCAROUTER_APP_NAME")"
+    url="${url}&scope=${scope}"
+
+    printf "\n" >&2
+    orcarouter:info "Authorize x-cmd in your browser, then paste the code back here:"
+    printf "\n    %s\n\n" "$url" >&2
+
+    if ___x_cmd_runmode_allow_manual 2>/dev/null; then
+        # stdin is detached: on a headless host the platform opener may fall
+        # back to a text browser (or to package auto-install), and either would
+        # otherwise swallow the authorization code the user is about to paste.
+        ___x_cmd open "$url" </dev/null >/dev/null 2>&1 \
+            || orcarouter:warn "Could not open a browser automatically; open the URL above yourself."
+    fi
+
+    local code=""
+    printf "Code: " >&2
+    IFS= read -r code 2>/dev/null || {
+        orcarouter:error "No authorization code provided."
+        return 1
+    }
+    # Strip pasted whitespace and any trailing CR. A small local trim is used
+    # deliberately: ___x_cmd_str_trim reads stdin when given no argument, which
+    # would consume the code rather than clean it.
+    code="$(printf '%s' "$code" | ___x_cmd_cmds_awk '{ sub(/\r$/, ""); gsub(/^[ \t]+|[ \t]+$/, ""); print; exit }')"
+    [ -n "$code" ] || {
+        orcarouter:error "No authorization code provided."
+        return 1
+    }
+
+    # Re-read the attempt record and verify the state still matches before the
+    # code is redeemed. This is the CSRF check: a clobbered, raced, or
+    # substituted attempt is refused rather than exchanged.
+    local recorded_state=""
+    recorded_state="$(___x_cmd_cmds_awk 'NR==2{print; exit}' "$attempt_file" 2>/dev/null)"
+    if ! ___x_cmd_orcarouter_util_ct_eq "$recorded_state" "$state"; then
+        orcarouter:error "State mismatch: this authorization attempt is not the one that was started."
+        orcarouter:warn "Refusing to exchange the code. Start again with 'x orcarouter connect --force'."
+        return 1
+    fi
+
+    # Bound the attempt: an authorization code is single-use with a 10 minute
+    # TTL, so a stale attempt is abandoned rather than sent.
+    local started=""; local now=""
+    started="$(___x_cmd_cmds_awk 'NR==3{print; exit}' "$attempt_file" 2>/dev/null)"
+    now="$(___x_cmd_orcarouter_util_now)"
+    case "$started" in
+        ''|*[!0-9]*) ;;
+        *)
+            if [ $((now - started)) -gt "$___X_CMD_ORCAROUTER_AUTH_CODE_TTL_SECONDS" ]; then
+                orcarouter:error "This authorization attempt has expired (over ${___X_CMD_ORCAROUTER_AUTH_CODE_TTL_SECONDS}s old)."
+                orcarouter:warn "Start a new one with 'x orcarouter connect --force'."
+                return 1
+            fi
+            ;;
+    esac
+
+    # 3. Exchange. The verifier travels only in this request body, to the AUTH
+    #    origin -- never to the inference origin, never as a query parameter.
+    local resp=""; local status=""
+    resp="$(___x_cmd_orcarouter_connect___exchange "$auth_base" "$code" "$verifier" "$scope")"
+    status="${resp##*$'\n'}"
+    resp="${resp%$'\n'*}"
+
+    if [ "$status" != "200" ]; then
+        ___x_cmd_orcarouter_connect___explain_failure "$status" "$resp"
+        return 1
+    fi
+
+    local key=""; local granted_scope=""
+    key="$(___x_cmd_orcarouter_connect___json_str "$resp" key)"
+    granted_scope="$(___x_cmd_orcarouter_connect___json_str "$resp" scope)"
+
+    [ -n "$key" ] || {
+        orcarouter:error "The authorization response did not contain a key."
+        return 1
+    }
+
+    # Read back the GRANTED scope; it may be narrower than what we asked for.
+    if [ -n "$granted_scope" ] && [ "$granted_scope" != "$scope" ]; then
+        orcarouter:warn "Granted scope is \"$granted_scope\", not the requested \"$scope\"."
+        orcarouter:warn "This workspace role does not permit the wider grant; continuing with the granted scope."
+    fi
+    case "${granted_scope:-api}" in
+        api|connector) ;;
+        *)  orcarouter:warn "Unexpected granted scope \"$granted_scope\"; the credential may not be usable." ;;
+    esac
+
+    ___x_cmd_orcarouter_cred_apply "$key" pkce "$granted_scope" || return $?
+
+    ___x_cmd_orcarouter_connect___cleanup
+    trap - EXIT HUP INT TERM
+
+    orcarouter:info "Connected. OrcaRouter credential stored as $(___x_cmd_orcarouter_cred_mask "$key")."
+    orcarouter:info "It is a durable key: it will be reused until you revoke it at"
+    orcarouter:info "  $___X_CMD_ORCAROUTER_AUTHORIZED_APPS_URL"
+    return 0
+}
+
+___x_cmd_orcarouter_connect___urlencode(){
+    local s="$1" out="" i=0 c=""
+    while [ "$i" -lt "${#s}" ]; do
+        c="$(printf "%s" "$s" | cut -c$((i + 1)))"
+        case "$c" in
+            [A-Za-z0-9.~_-])    out="${out}${c}" ;;
+            ' ')                out="${out}%20" ;;
+            *)                  out="${out}$(printf "%%%02X" "'$c")" ;;
+        esac
+        i=$((i + 1))
+    done
+    printf "%s" "$out"
+}
+
+___x_cmd_orcarouter_connect___exchange(){
+    local auth_base="$1"; local code="$2"; local verifier="$3"; local scope="$4"
+
+    local body=""
+    body="$(___x_cmd jq -n \
+        --arg code "$code" \
+        --arg verifier "$verifier" \
+        '{code: $code, code_verifier: $verifier, code_challenge_method: "S256"}' 2>/dev/null)"
+
+    [ -n "$body" ] || {
+        orcarouter:error "Could not build the exchange request body."
+        return 1
+    }
+
+    ___x_cmd curl -sS -X POST \
+        "${auth_base}${___X_CMD_ORCAROUTER_EXCHANGE_PATH}" \
+        -H 'Content-Type: application/json' \
+        --data "$body" \
+        -w '\n%{http_code}' 2>/dev/null
+}
+
+# Map the documented exchange failures onto an actionable message. Nothing from
+# the response body is echoed when it could carry a credential.
+___x_cmd_orcarouter_connect___explain_failure(){
+    local status="$1"
+    case "$status" in
+        400)    orcarouter:error "Authorization rejected (400): the code challenge method was not recognised, or it differs from the one sent at authorize time."
+                orcarouter:warn "Retry with 'x orcarouter connect --force'." ;;
+        403)    orcarouter:error "Authorization rejected (403): the code is unknown, expired, already used, or the verifier did not match."
+                orcarouter:warn "Codes are single-use with a 10 minute lifetime. Retry with 'x orcarouter connect --force'." ;;
+        429)    orcarouter:error "Authorization refused (429): too many keys have been issued for this account recently."
+                orcarouter:warn "OrcaRouter allows 10 PKCE-issued keys per user per 24 hours. Reuse the stored key, or wait before retrying." ;;
+        "")     orcarouter:error "The authorization exchange did not complete: no response from the authentication origin."
+                orcarouter:warn "Check your network and the authentication endpoint, then retry." ;;
+        *)      orcarouter:error "The authorization exchange failed with HTTP $status."
+                orcarouter:warn "Retry with 'x orcarouter connect --force'; if it persists, check the OrcaRouter status." ;;
+    esac
+    return 1
+}
+
+# Minimal extractor for the flat string fields this flow needs, so the
+# credential path does not depend on a jq binary being downloadable.
+___x_cmd_orcarouter_connect___json_str(){
+    local json="$1"; local field="$2"
+    printf "%s" "$json" | ___x_cmd_cmds_awk -v f="$field" '
+    {
+        line = $0
+        pat = "\"" f "\"[ \t]*:[ \t]*\""
+        if (match(line, pat)) {
+            rest = substr(line, RSTART + RLENGTH)
+            if (match(rest, /[^"\\]/)) {
+                rest = substr(rest, RSTART)
+                out = ""
+                n = length(rest)
+                for (i = 1; i <= n; i++) {
+                    c = substr(rest, i, 1)
+                    if (c == "\\") { i++; out = out substr(rest, i, 1); continue }
+                    if (c == "\"") break
+                    out = out c
+                }
+                print out
+                exit
+            }
+        }
+    }'
+}
+
+# Explicit sign-out. Removes the stored credential; never runs silently on a
+# transient failure.
+___x_cmd_orcarouter_disconnect(){
+    local X_help_cmd='___x_cmd help -m orcarouter disconnect'; help:arg:parse
+    ___x_cmd_orcarouter_cred_status 2>/dev/null
+    ___x_cmd_orcarouter_cred_clear
+    return 0
+}

--- a/mod/orcarouter/lib/cred
+++ b/mod/orcarouter/lib/cred
@@ -1,0 +1,161 @@
+# shellcheck shell=dash
+
+# The credential seam for OrcaRouter.
+#
+# Two adapters produce a credential and hand it to ___x_cmd_orcarouter_cred_apply:
+#
+#   API-key adapter  mod/orcarouter/lib/cfg        (apikey=<sk-orca-...>)
+#   PKCE adapter     mod/orcarouter/lib/connect    (x orcarouter connect)
+#
+# Everything downstream -- the chat transport, the model catalogue, the
+# Claude Code harness, the agent provider catalogs -- reads the credential
+# through this file and never learns which adapter produced it. Authentication
+# logic is not duplicated per entry point.
+#
+# Storage is the project's existing config store (cfgy), the same one every
+# other provider uses. No new secret store is introduced.
+
+# The raw key. Callers must not print this.
+#
+# Resolution order: the project's config store (populated by either adapter),
+# then the environment. Existing x-cmd users already keep provider keys in the
+# environment, so the env path is honoured rather than forcing a config write.
+___x_cmd_orcarouter_cred_key_raw(){
+    # cfgy's `name:=` form assigns into a dynamically-scoped variable literally
+    # named `name`, so this local must carry that exact name.
+    local apikey=
+    ___x_cmd_orcarouter_cur apikey:= 2>/dev/null
+    [ -n "$apikey" ] || apikey="${ORCAROUTER_API_KEY:-}"
+    [ -n "$apikey" ] || apikey="${ORCA_KEY:-}"
+    printf "%s" "$apikey"
+}
+
+___x_cmd_orcarouter_cred_source(){
+    local credsrc=
+    ___x_cmd_orcarouter_cur credsrc:= 2>/dev/null
+    local s="$credsrc"
+    if [ -z "$s" ]; then
+        # Present without a stored record => it came from the environment.
+        if [ -n "${ORCAROUTER_API_KEY:-}" ] || [ -n "${ORCA_KEY:-}" ]; then
+            s=env
+        elif [ -n "$(___x_cmd_orcarouter_cred_key_raw)" ]; then
+            s=apikey
+        fi
+    fi
+    printf "%s" "$s"
+}
+
+___x_cmd_orcarouter_cred_generation(){
+    local credgen=
+    ___x_cmd_orcarouter_cur credgen:= 2>/dev/null
+    printf "%s" "${credgen:-0}"
+}
+
+___x_cmd_orcarouter_cred_needs_reauth(){
+    local needsreauth=
+    ___x_cmd_orcarouter_cur needsreauth:= 2>/dev/null
+    [ "$needsreauth" = "1" ]
+}
+
+# Show only enough of the key to recognise it. Never the whole value.
+___x_cmd_orcarouter_cred_mask(){
+    local k="$1"
+    [ -n "$k" ] || { printf "%s" ""; return 0; }
+    if [ "${#k}" -le 12 ]; then
+        printf "%s" "****"
+    else
+        printf "%s...%s" "$(printf "%s" "$k" | cut -c1-8)" "$(printf "%s" "$k" | cut -c$(( ${#k} - 3 ))- )"
+    fi
+}
+
+# Both adapters land here. $1 = key, $2 = source (apikey|pkce), $3 = granted scope.
+# A successful apply always clears the reauth marker and issues a NEW generation,
+# so a failure belonging to the previous credential can no longer touch this one.
+___x_cmd_orcarouter_cred_apply(){
+    local key="$1"; local source="$2"; local scope="$3"
+    [ -n "$key" ] || { orcarouter:error "No credential to store."; return 1; }
+    orcarouter:debug "Storing OrcaRouter credential (source=$source mask=$(___x_cmd_orcarouter_cred_mask "$key"))"
+
+    local gen=0
+    gen="$(___x_cmd_orcarouter_cred_generation)"
+    case "$gen" in ''|*[!0-9]*) gen=0 ;; esac
+    gen=$((gen + 1))
+
+    ___x_cmd_orcarouter_cfg___invoke \
+        set apikey="$key" credsrc="$source" credgen="$gen" needsreauth= reauthgen= \
+        ${scope:+scope="$scope"} >/dev/null 2>&1 || {
+        orcarouter:error "Failed to save the OrcaRouter credential to the local config."
+        return 1
+    }
+    return 0
+}
+
+# Terminal reauthentication. ONLY the exact credential generation that made the
+# rejected request may be marked. A late 401 from an old generation must never
+# invalidate a credential the user has since replaced.
+___x_cmd_orcarouter_cred_mark_reauth(){
+    local rejected_gen="$1"
+    local cur_gen=""
+    cur_gen="$(___x_cmd_orcarouter_cred_generation)"
+
+    if [ -n "$rejected_gen" ] && [ "$rejected_gen" != "$cur_gen" ]; then
+        orcarouter:debug "Ignoring stale 401 from generation [$rejected_gen]; current is [$cur_gen]."
+        return 0
+    fi
+
+    ___x_cmd_orcarouter_cfg___invoke \
+        set needsreauth=1 reauthgen="$cur_gen" >/dev/null 2>&1
+
+    orcarouter:error "The OrcaRouter credential for this account was rejected (HTTP 401)."
+    orcarouter:warn "It has been marked as needing reauthentication and will not be used again."
+    orcarouter:warn "Sign in again with ==>  x orcarouter connect"
+    orcarouter:warn "Or paste a fresh key ==>  x orcarouter --cfg apikey=<your api key>"
+    return 0
+}
+
+# Used by the chat path. A durable OrcaRouter key is NOT a refresh token: there
+# is no refresh endpoint and nothing here attempts a refresh grant. A 401 is
+# terminal for this credential generation.
+___x_cmd_orcarouter_cred_handle_401(){
+    local gen="$1"
+    ___x_cmd_orcarouter_cred_mark_reauth "$gen"
+}
+
+# Clear the credential. Deliberately explicit: nothing silently deletes a
+# stored secret on a transient failure.
+___x_cmd_orcarouter_cred_clear(){
+    ___x_cmd_orcarouter_cfg___invoke \
+        set apikey= credsrc= credgen= needsreauth= reauthgen= >/dev/null 2>&1
+    orcarouter:info "The stored OrcaRouter credential has been removed."
+}
+
+___x_cmd_orcarouter_cred_status(){
+    local k=""; k="$(___x_cmd_orcarouter_cred_key_raw)"
+    if [ -z "$k" ]; then
+        orcarouter:info "OrcaRouter: no credential configured."
+        orcarouter:info "  Paste a key : x orcarouter --cfg apikey=<sk-orca-...>"
+        orcarouter:info "  Sign in     : x orcarouter connect"
+        return 0
+    fi
+
+    local src=""; src="$(___x_cmd_orcarouter_cred_source)"
+    local gen=""; gen="$(___x_cmd_orcarouter_cred_generation)"
+    local scope=""; ___x_cmd_orcarouter_cur scope:= 2>/dev/null
+    : "${scope:=}"
+
+    orcarouter:info "OrcaRouter credential: $(___x_cmd_orcarouter_cred_mask "$k")"
+    case "$src" in
+        pkce)   orcarouter:info "  Source     : OAuth 2.0 + PKCE account login" ;;
+        apikey) orcarouter:info "  Source     : API key" ;;
+        *)      orcarouter:info "  Source     : (unknown)" ;;
+    esac
+    orcarouter:info "  Generation : ${gen:-0}"
+    [ -n "$scope" ] && orcarouter:info "  Scope      : $scope"
+
+    if ___x_cmd_orcarouter_cred_needs_reauth; then
+        orcarouter:warn "  State      : NEEDS REAUTHENTICATION -- run 'x orcarouter connect' again."
+        return 1
+    fi
+    orcarouter:info "  State      : ok"
+    return 0
+}

--- a/mod/orcarouter/lib/credits
+++ b/mod/orcarouter/lib/credits
@@ -1,0 +1,49 @@
+# shellcheck shell=dash
+xrc ourl
+
+___x_cmd_orcarouter_credits(){
+    local format=yml
+    local op="$1";
+    case "$op" in
+        -j|--json)  shift; format=json      ;;
+        -y|--yml)   shift; format=yml       ;;
+        -h|--help)  shift; ___x_cmd help -m orcarouter credits "$@"; return ;;
+    esac
+
+    ___x_cmd_orcarouter_credits_"${format}" "$@"
+}
+
+___x_cmd_orcarouter_credits_yml(){
+    local data; data="$( ___x_cmd_orcarouter_credits_raw )" || ourl:data:ret
+    ___x_cmd_pipevar data ___x_cmd j2y
+}
+
+___x_cmd_orcarouter_credits_json(){
+    local data; data="$( ___x_cmd_orcarouter_credits_raw )" || ourl:data:ret
+    ___x_cmd_pipevar data ___x_cmd jo fmt
+}
+
+# Reports the credential lifecycle state. OrcaRouter has no documented public
+# credit-balance endpoint, so this deliberately does not invent one: it reports
+# what is locally known about the credential instead of making a billing call.
+___x_cmd_orcarouter_credits_raw(){
+    local k=""; k="$(___x_cmd_orcarouter_cred_key_raw)"
+    [ -n "$k" ] || {
+        orcarouter:error "No OrcaRouter credential configured."
+        orcarouter:warn "Set one up ==>  x orcarouter --cfg apikey=<your api key>"
+        return 1
+    }
+
+    local src=""; src="$(___x_cmd_orcarouter_cred_source)"
+    local gen=""; gen="$(___x_cmd_orcarouter_cred_generation)"
+    local state="ok"
+    ___x_cmd_orcarouter_cred_needs_reauth && state="needs_reauth"
+
+    ___x_cmd jq -n \
+        --arg key "$(___x_cmd_orcarouter_cred_mask "$k")" \
+        --arg source "${src:-unknown}" \
+        --arg generation "${gen:-0}" \
+        --arg state "$state" \
+        --arg console "$___X_CMD_ORCAROUTER_AUTHORIZED_APPS_URL" \
+        '{key: $key, source: $source, generation: $generation, state: $state, console: $console}'
+}

--- a/mod/orcarouter/lib/main
+++ b/mod/orcarouter/lib/main
@@ -1,0 +1,57 @@
+# shellcheck shell=dash
+
+___x_cmd log init orcarouter
+xrc:mod         str/latest
+xrc:mod:lib     orcarouter    util cfg cred connect model chat/_index credits
+
+# Inference origin. /v1 is appended by the shared OpenAI adapter in
+# mod/openai/lib/chat/send, so this value deliberately carries no /v1.
+___X_CMD_ORCAROUTER_DEFAULT_ENDPOINT="https://api.orcarouter.ai"
+
+# Authentication origin. Deliberately a DIFFERENT host from inference:
+# the relay lives on api.orcarouter.ai/v1, the auth endpoints on
+# www.orcarouter.ai/api/v1/auth. Never derive one from the other.
+___X_CMD_ORCAROUTER_DEFAULT_AUTH_ENDPOINT="https://www.orcarouter.ai"
+
+___X_CMD_ORCAROUTER_DEFAULT_FIRST_MODEL="openai/gpt-5.5"
+
+___X_CMD_ORCAROUTER_AUTHORIZE_PATH="/auth"
+___X_CMD_ORCAROUTER_EXCHANGE_PATH="/api/v1/auth/keys"
+___X_CMD_ORCAROUTER_DEVICE_CODE_PATH="/api/v1/auth/device/code"
+___X_CMD_ORCAROUTER_DEVICE_TOKEN_PATH="/api/v1/auth/device/token"
+
+___X_CMD_ORCAROUTER_APP_NAME="x-cmd"
+
+# Console pages, quoted in help and error messages.
+___X_CMD_ORCAROUTER_KEYS_URL="https://www.orcarouter.ai/console/keys"
+___X_CMD_ORCAROUTER_AUTHORIZED_APPS_URL="https://www.orcarouter.ai/console/authorized-apps"
+
+# Authorization code lifetime advertised by the service.
+___X_CMD_ORCAROUTER_AUTH_CODE_TTL_SECONDS=600
+
+___x_cmd_orcarouter___main(){
+    [ "$#" -gt 0 ] ||   set -- --help
+
+    local op="$1";      shift
+    case "$op" in
+        chat)               ___x_cmd_orcarouter_chat          "$@"   ;;
+        connect|login)      ___x_cmd_orcarouter_connect       "$@"   ;;
+        disconnect|logout)  ___x_cmd_orcarouter_disconnect    "$@"   ;;
+        init|--init)        ___x_cmd_orcarouter_init          "$@"   ;;
+        model|credits)      ___x_cmd_orcarouter_"$op"         "$@"   ;;
+        --cur|--cfg)        ___x_cmd_orcarouter_"${op#--}"    "$@"   ;;
+        --has-apikey)       ___x_cmd_orcarouter_has_apikey    "$@"   ;;
+        --list-model-fast)  ___x_cmd_orcarouter_list_model_fast "$@" ;;
+        -h|--help)          ___x_cmd help -m orcarouter "$@";  return 0 ;;
+        *)                  ___x_cmd help -m orcarouter "$@";  return 64 ;;
+    esac
+}
+
+___x_cmd_orcarouter_list_model_fast(){
+    printf "%s\n" \
+        openai/gpt-5.5 \
+        anthropic/claude-opus-4.8 \
+        google/gemini-3.5-flash \
+        deepseek/deepseek-v4-pro \
+        orcarouter/auto
+}

--- a/mod/orcarouter/lib/model
+++ b/mod/orcarouter/lib/model
@@ -1,0 +1,350 @@
+# shellcheck shell=dash
+xrc ourl
+
+# OrcaRouter model catalogue.
+#
+# The single source of truth for the model list is
+#   GET <inference origin>/v1/models
+# and, when a capability is selected,
+#   GET <inference origin>/v1/models?capability=<capability>
+# fetched with the user's own Bearer key so the list reflects the models that
+# workspace can actually call.
+#
+# A verified cold-start seed is kept ONLY for the case where live discovery
+# fails; when live discovery succeeds its result is authoritative and the seed
+# is not mixed in.
+#
+# Capability filters are derived from catalogue metadata alone -- never from a
+# model's name. Records that declare nothing fail closed.
+
+# Bounds: a catalogue response must not be able to consume unbounded memory or
+# advertise routes this client cannot speak.
+___X_CMD_ORCAROUTER_MODEL_MAX_ITEMS=500
+___X_CMD_ORCAROUTER_MODEL_TIMEOUT=20
+
+___x_cmd_orcarouter_model(){
+    [ $# -gt 0 ]    ||      set - ls
+
+    local op="$1";  shift
+    case "$op" in
+        ls|set|get)
+            ___x_cmd_orcarouter_model_"$op" "$@"
+            ;;
+        -h|--help)
+            ___x_cmd help -m orcarouter model "$@"
+            ;;
+        *)
+            N=orcarouter M="Not support [subcmd=$op]" log:ret:64
+    esac
+}
+
+___x_cmd_orcarouter_model_set(){
+    local model="$1"
+    [ -n "$model" ] || orcarouter:error "Please provide a model name"
+
+    ___x_cmd_orcarouter_cfg set model="$model" || return $?
+    orcarouter:info "The default model has been set as $model"
+}
+
+___x_cmd_orcarouter_model_get(){
+    local model=""
+    ___x_cmd_orcarouter_cur model:=  2>/dev/null
+    printf "%s\n" "$model"
+}
+
+# --- capability selection ----------------------------------------------------
+
+# NORMALISED CAPABILITY and MODALITY are exported to the parser below.
+___x_cmd_orcarouter_model___resolve_capability(){
+    NORMALISED_CAP=chat
+    NORMALISED_MODALITY=
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --chat)         NORMALISED_CAP=chat ;;
+            --embedding)    NORMALISED_CAP=embedding ;;
+            --image)        NORMALISED_CAP=image ;;
+            --video)        NORMALISED_CAP=video ;;
+            --rerank)       NORMALISED_CAP=rerank ;;
+            --vision)       NORMALISED_CAP=chat; NORMALISED_MODALITY=image ;;
+            --multimodal)   NORMALISED_CAP=chat; NORMALISED_MODALITY="${2:-image}"; shift ;;
+            --audio)        NORMALISED_CAP=chat; NORMALISED_MODALITY=audio ;;
+            --file)         NORMALISED_CAP=chat; NORMALISED_MODALITY=file ;;
+            --capability)   NORMALISED_CAP="${2:-chat}"; shift ;;
+            --modality)     NORMALISED_MODALITY="${2:-}"; shift ;;
+        esac
+        shift
+    done
+}
+
+___x_cmd_orcarouter_model_ls(){
+    local format=app
+
+    ___x_cmd_orcarouter_model___resolve_capability "$@"
+
+    # Strip the capability flags; what remains is the output-format selector.
+    local rest=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --chat|--embedding|--image|--video|--rerank|--vision|--audio|--file) ;;
+            --multimodal|--capability|--modality)   shift ;;
+            *)  rest="${rest} $1" ;;
+        esac
+        shift
+    done
+    set -- $rest
+
+    local op="${1:---app}"
+    case "$op" in
+        --csv)      format=csv       ;;
+        --app)      format=app       ;;
+        -j|--json)  format=json      ;;
+        -y|--yml)   format=yml       ;;
+        -h|--help)  ___x_cmd help -m orcarouter model ls  "$@"; return ;;
+        *)          N=orcarouter M="Not support [option=$op]" log:ret:64; return 64 ;;
+    esac
+
+    "___x_cmd_orcarouter_model_ls___${format}"
+}
+
+___x_cmd_orcarouter_model_ls___app(){
+    if ! { ___x_cmd_is_stdout2tty && ___x_cmd_runmode_allow_manual; }; then
+        ___x_cmd_orcarouter_model_ls___csv "$@"
+        return $?
+    fi
+
+    local ___X_CMD_CSV_APP_DATA_CURROW=
+    local data; data="$( ___x_cmd_orcarouter_model_ls___csv )" || ourl:data:ret
+    ___x_cmd_pipevar    data    ___x_cmd csv --app --return line
+
+    if [ -n "$___X_CMD_CSV_APP_DATA_CURROW" ] ; then
+        local select_id="${___X_CMD_CSV_APP_DATA_CURROW%%,*}"
+        local id=""
+        orcarouter:info "Select model -> $select_id"
+        ___x_cmd ui select id "What to do NEXT" \
+        "set default model: $select_id"    \
+        "EXIT"     || return $?
+
+        case "$id" in
+            1)  ___x_cmd_orcarouter_model_set "$select_id" ;;
+            2)
+                orcarouter:info "EXIT [code=0]"
+                return 0 ;;
+        esac
+    fi
+}
+
+___x_cmd_orcarouter_model_ls___csv(){
+    local data; data="$( ___x_cmd_orcarouter_model_ls_tsv )" || ourl:data:ret
+    printf "%s" "$data" | ___x_cmd_orcarouter_model_ls___tsv2csv
+}
+___x_cmd_orcarouter_model_ls___json(){
+    local data; data="$( ___x_cmd_orcarouter_model_ls_tsv )" || ourl:data:ret
+    printf "%s" "$data" | ___x_cmd_orcarouter_model_ls___tsv2json | ___x_cmd jo fmt
+}
+___x_cmd_orcarouter_model_ls___yml(){
+    local data; data="$( ___x_cmd_orcarouter_model_ls_tsv )" || ourl:data:ret
+    printf "%s" "$data" | ___x_cmd_orcarouter_model_ls___tsv2json | ___x_cmd j2y
+}
+
+___x_cmd_orcarouter_model_ls___tsv2csv(){
+    ___x_cmd_cmds_awk -F'\t' 'BEGIN{
+        OFS=","
+        print "Id","Name","ContextLength","InputModalities","OutputModalities","EndpointTypes","Source"
+    }
+    {
+        for (i = 1; i <= 7; i++) {
+            v = $i
+            gsub(/"/, "\"\"", v)
+            if (v ~ /[",]/) v = "\"" v "\""
+            $i = v
+        }
+        print $1,$2,$3,$4,$5,$6,$7
+    }'
+}
+
+___x_cmd_orcarouter_model_ls___tsv2json(){
+    ___x_cmd_cmds_awk -F'\t' '
+    function esc(s) { gsub(/\\/, "\\\\", s); gsub(/"/, "\\\"", s); return s }
+    BEGIN{ printf "[" }
+    {
+        if (NR>1) printf ","
+        printf "{\"id\":\"%s\",\"name\":\"%s\",\"context_length\":\"%s\",\"input_modalities\":\"%s\",\"output_modalities\":\"%s\",\"supported_endpoint_types\":\"%s\",\"source\":\"%s\"}", esc($1),esc($2),esc($3),esc($4),esc($5),esc($6),esc($7)
+    }
+    END{ printf "]\n" }'
+}
+
+# Fetches and filters, emitting TSV. Falls back to the verified seed when live
+# discovery fails, marking every row as a fallback so the degradation is
+# visible rather than silent.
+___x_cmd_orcarouter_model_ls_tsv(){
+    ___x_cmd_orcarouter_model_ls_tsv_live && return 0
+
+    orcarouter:warn "Live model discovery failed; showing the verified fallback catalogue."
+    orcarouter:warn "The list may be incomplete or out of date. Run 'x orcarouter model ls' again to retry."
+    ___x_cmd_orcarouter_model_ls_tsv_seed
+}
+
+___x_cmd_orcarouter_model_ls_tsv_live(){
+    local apikey=""; apikey="$(___x_cmd_orcarouter_cred_key_raw)"
+    [ -n "$apikey" ] || {
+        orcarouter:error "No OrcaRouter credential configured, so the live model catalogue cannot be read."
+        orcarouter:warn "Set one up ==>  x orcarouter --cfg apikey=<your api key>"
+        orcarouter:warn "Or sign in   ==>  x orcarouter connect"
+        return 1
+    }
+
+    local api_base=""; api_base="$(___x_cmd_orcarouter_util_api_base_v1)"
+    ___x_cmd_orcarouter_util_require_origin "inference" "$api_base" || return 1
+
+    local url="${api_base}/models"
+    case "$NORMALISED_CAP" in
+        chat|embedding|image|video|rerank) url="${url}?capability=${NORMALISED_CAP}" ;;
+    esac
+
+    # Body and status are captured separately so a bounded, non-2xx or empty
+    # response can never be mistaken for a catalogue.
+    local tmp_dir=""; tmp_dir="$(___x_cmd_orcarouter_util_attempt_dir)"
+    local body_file="${tmp_dir}/models.$$"
+    local status=""
+    status="$(___x_cmd curl -sS \
+        --max-time "$___X_CMD_ORCAROUTER_MODEL_TIMEOUT" \
+        -H "Authorization: Bearer $apikey" \
+        -o "$body_file" -w '%{http_code}' \
+        "$url" 2>/dev/null)"
+
+    if [ "$status" = "401" ] || [ "$status" = "403" ]; then
+        # Terminal for this credential generation. Reuses the exact-generation
+        # rule; no refresh is attempted, because there is no refresh grant.
+        ___x_cmd_orcarouter_cred_mark_reauth "$(___x_cmd_orcarouter_cred_generation)"
+        ___x_cmd rmrf "$body_file" 2>/dev/null
+        return 1
+    fi
+    [ "$status" = "200" ] || {
+        ___x_cmd rmrf "$body_file" 2>/dev/null
+        return 1
+    }
+
+    local out=""
+    out="$(___x_cmd_orcarouter_model___json2rows < "$body_file" | ___x_cmd_orcarouter_model_parse)"
+    ___x_cmd rmrf "$body_file" 2>/dev/null
+
+    [ -n "$out" ] || return 1
+    printf "%s\n" "$out"
+    return 0
+}
+
+# Normalises each catalogue record into one flat "|"-separated line. Anything
+# the parser sees is metadata the service actually declared; nothing is inferred
+# from a model's name.
+___x_cmd_orcarouter_model___json2rows(){
+    ___x_cmd jq -r '
+        .data[]? |
+        [
+            (.id // ""),
+            ((.name // "") | gsub("\\|"; "/") | gsub("[\\r\\n\\t]"; " ")),
+            ((.context_length // "") | tostring),
+            ((.architecture.input_modalities // []) | join(",")),
+            ((.architecture.output_modalities // []) | join(",")),
+            ((.supported_endpoint_types // []) | join(","))
+        ] | join("|")
+    ' 2>/dev/null
+}
+
+# Parses a /v1/models body into TSV, applying the capability rules.
+___x_cmd_orcarouter_model_parse(){
+    ___x_cmd_cmds_awk \
+        -v cap="$NORMALISED_CAP" \
+        -v modality="$NORMALISED_MODALITY" \
+        -v maxitems="$___X_CMD_ORCAROUTER_MODEL_MAX_ITEMS" '
+    function arr_has(arr, needle,   n, i, parts) {
+        if (arr == "") return 0
+        n = split(arr, parts, ",")
+        for (i = 1; i <= n; i++) if (parts[i] == needle) return 1
+        return 0
+    }
+    BEGIN {
+        FS = "\t"
+        OFS = "\t"
+        TEXT["openai"]=1; TEXT["anthropic"]=1; TEXT["gemini"]=1; TEXT["openai-response"]=1
+        NONTEXT["image-generation"]=1; NONTEXT["openai-video"]=1; NONTEXT["jina-rerank"]=1
+        count = 0
+    }
+    # Records are read as one flat object per entry: the extractor below emits
+    # "id|name|ctx|in|out|ep" per line.
+    {
+        if (count >= maxitems) next
+        split($0, f, "|")
+        id=f[1]; name=f[2]; ctx=f[3]; im=f[4]; om=f[5]; ep=f[6]
+        if (id == "") next
+
+        keep = 0
+        if (cap == "embedding") {
+            keep = arr_has(ep, "embeddings")
+        } else if (cap == "image") {
+            keep = arr_has(ep, "image-generation")
+        } else if (cap == "video") {
+            keep = arr_has(ep, "openai-video")
+        } else if (cap == "rerank") {
+            keep = arr_has(ep, "jina-rerank")
+        } else {
+            # text chat: must speak at least one text endpoint, and must not be
+            # a non-text-only model. No `switch` here: the x-cmd awk is mawk,
+            # which does not implement it.
+            n = split(ep, eps, ",")
+            has_text = 0; has_other = 0
+            for (i = 1; i <= n; i++) {
+                if (eps[i] in TEXT) has_text = 1
+                if (!(eps[i] in NONTEXT)) has_other = 1
+            }
+            keep = has_text && has_other
+            # multimodal: additionally require the declared input modality.
+            # A record that declares no architecture fails closed.
+            if (keep && modality != "") keep = arr_has(im, modality)
+        }
+        if (!keep) next
+
+        count++
+        print id, name, ctx, im, om, ep, "api"
+    }'
+}
+
+# --- verified cold-start seed ------------------------------------------------
+#
+# Re-verified against the live catalogue on 2026-09-11. Used only when live
+# discovery fails. Modality metadata is preserved so a multimodal filter does
+# not accidentally widen or narrow incorrectly.
+___x_cmd_orcarouter_model_ls_tsv_seed(){
+    local mod="$NORMALISED_MODALITY"
+    [ "$NORMALISED_CAP" = "chat" ] || return 0
+
+    # openai/gpt-5.5 -- live catalogue reports file,image,text
+    ___x_cmd_orcarouter_model_seed_row_if "$mod" "file,image,text" \
+        "openai/gpt-5.5" "OpenAI: GPT-5.5" "" "file,image,text" "text" "openai,openai-response"
+    # anthropic/claude-opus-4.8 -- text,image,file @ 1000000
+    ___x_cmd_orcarouter_model_seed_row_if "$mod" "text,image,file" \
+        "anthropic/claude-opus-4.8" "Anthropic: Claude Opus 4.8" "1000000" "text,image,file" "text" "openai,anthropic,openai-response"
+    # google/gemini-3.5-flash -- text,image,video,file,audio @ 1048576
+    ___x_cmd_orcarouter_model_seed_row_if "$mod" "text,image,video,file,audio" \
+        "google/gemini-3.5-flash" "Google: Gemini 3.5 Flash" "1048576" "text,image,video,file,audio" "text" "openai,gemini"
+    # deepseek/deepseek-v4-pro -- text only @ 1048576
+    ___x_cmd_orcarouter_model_seed_row_if "$mod" "text" \
+        "deepseek/deepseek-v4-pro" "DeepSeek: DeepSeek V4 Pro" "1048576" "text" "text" "openai,openai-response"
+    # orcarouter/auto -- router alias, declares no modality upstream
+    if [ -z "$mod" ]; then
+        printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+            "orcarouter/auto" "OrcaRouter: Auto" "" "" "" "openai,openai-response,anthropic,gemini" "seed"
+    fi
+}
+
+___x_cmd_orcarouter_model_seed_row_if(){
+    local want_mod="$1"; local have_mods="$2"
+    shift 2
+    if [ -n "$want_mod" ]; then
+        case ",${have_mods}," in
+            *",${want_mod},"*) ;;
+            *) return 0 ;;
+        esac
+    fi
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\n" "$1" "$2" "$3" "$4" "$5" "$6" "seed"
+}

--- a/mod/orcarouter/lib/util
+++ b/mod/orcarouter/lib/util
@@ -1,0 +1,177 @@
+# shellcheck shell=dash
+
+# Shared helpers for the OrcaRouter provider: origin resolution, origin policy,
+# and the PKCE crypto primitives (base64url + SHA-256).
+#
+# No third-party dependency is introduced for either: every platform x-cmd
+# already supports ships `openssl` (wrapped as `___x_cmd openssl`) and a
+# POSIX `base64`.
+
+# --- Origins -----------------------------------------------------------------
+#
+# Authentication and inference live on different public origins:
+#
+#   auth      https://www.orcarouter.ai      (authorize + code exchange)
+#   inference https://api.orcarouter.ai/v1   (chat, model catalogue)
+#
+# They are never derived from one another by rewriting a hostname or blindly
+# appending /v1. Precedence, explicit first:
+#
+#   config value  >  ORCA_<PURPOSE>_BASE_URL  >  ORCA_BASE_URL  >  default
+
+___x_cmd_orcarouter_util_auth_base(){
+    # `authbase:=` assigns into a dynamically-scoped `authbase`, per cfgy.
+    local authbase=
+    ___x_cmd_orcarouter_cur authbase:= 2>/dev/null
+    local v="$authbase"
+    [ -n "$v" ] || v="${ORCA_AUTH_BASE_URL:-}"
+    [ -n "$v" ] || v="${ORCA_BASE_URL:-}"
+    [ -n "$v" ] || v="$___X_CMD_ORCAROUTER_DEFAULT_AUTH_ENDPOINT"
+    ___x_cmd_orcarouter_util_strip_slash "$v"
+}
+
+___x_cmd_orcarouter_util_api_base(){
+    # `endpoint:=` assigns into a dynamically-scoped `endpoint`, per cfgy.
+    local endpoint=
+    ___x_cmd_orcarouter_cur endpoint:= 2>/dev/null
+    local v="$endpoint"
+    [ -n "$v" ] || v="${ORCA_API_BASE_URL:-}"
+    [ -n "$v" ] || v="${ORCA_BASE_URL:-}"
+    [ -n "$v" ] || v="$___X_CMD_ORCAROUTER_DEFAULT_ENDPOINT"
+    ___x_cmd_orcarouter_util_strip_slash "$v"
+}
+
+# Inference lives under /v1 on the relay; accept a base that already carries it
+# so a self-hosted ORCA_BASE_URL copied from the docs does not become /v1/v1.
+___x_cmd_orcarouter_util_api_base_v1(){
+    local b=""; b="$(___x_cmd_orcarouter_util_api_base)"
+    case "$b" in
+        */v1)   printf "%s\n" "$b"          ;;
+        *)      printf "%s\n" "$b/v1"       ;;
+    esac
+}
+
+___x_cmd_orcarouter_util_strip_slash(){
+    local v="$1"
+    while [ "${v%/}" != "$v" ]; do v="${v%/}"; done
+    printf "%s\n" "$v"
+}
+
+# Loopback HTTP is allowed for local development; every other origin must be
+# HTTPS. This mirrors the service's own callback_url rule.
+___x_cmd_orcarouter_util_origin_allowed(){
+    local url="$1"
+    case "$url" in
+        https://*)  return 0 ;;
+        http://localhost|http://localhost/*|http://localhost:*)     return 0 ;;
+        http://127.0.0.1|http://127.0.0.1/*|http://127.0.0.1:*)     return 0 ;;
+        'http://[::1]'|'http://[::1]/*'|'http://[::1]:'*)           return 0 ;;
+        *)          return 1 ;;
+    esac
+}
+
+___x_cmd_orcarouter_util_require_origin(){
+    local purpose="$1" url="$2"
+    ___x_cmd_orcarouter_util_origin_allowed "$url" && return 0
+    orcarouter:error "Refusing non-HTTPS $purpose origin [$url]: only HTTPS is accepted for remote origins (plain HTTP is permitted for loopback development)."
+    return 1
+}
+
+# --- PKCE crypto -------------------------------------------------------------
+
+# 64 hex chars -> base64url without padding.
+# Built from pure shell arithmetic so it works on a bare POSIX shell with no
+# python/perl/xxd present.
+___x_cmd_orcarouter_util_b64url_hex(){
+    local hex="$1"
+    [ -n "$hex" ] || return 1
+    local n=0 i=0 out=""
+    out="$( (
+        i=0
+        while [ "$i" -lt "${#hex}" ]; do
+            p="$(printf "%s" "$hex" | cut -c$((i + 1))-$((i + 2)))"
+            printf "\\$(printf "%03o" "$((16#$p))")"
+            i=$((i + 2))
+        done
+    ) | base64 | tr -d '\n=' | tr '+/' '-_' )" || return 1
+    printf "%s\n" "$out"
+}
+
+# base64 -> base64url without padding (used for random byte strings).
+___x_cmd_orcarouter_util_b64url_of_b64(){
+    printf "%s" "$1" | tr -d '\n=' | tr '+/' '-_'
+}
+
+___x_cmd_orcarouter_util_sha256_b64url(){
+    local s="$1"
+    [ -n "$s" ] || return 1
+    local hex=""
+    hex="$(___x_cmd_str_sha256 "$s")" || return 1
+    [ -n "$hex" ] || return 1
+    ___x_cmd_orcarouter_util_b64url_hex "$hex"
+}
+
+# $1 = number of random bytes to draw from the platform CSPRNG.
+# Reads /dev/urandom first; falls back to `openssl rand`. Never derived from
+# time, pid, hostname or any other guessable value.
+___x_cmd_orcarouter_util_rand_b64url(){
+    local n="${1:-32}"
+    local raw=""
+    if [ -r /dev/urandom ]; then
+        raw="$(___x_cmd_cmds dd if=/dev/urandom bs=1 count="$n" 2>/dev/null | base64 | tr -d '\n')"
+    fi
+    if [ -z "$raw" ]; then
+        raw="$(___x_cmd openssl rand -base64 "$n" 2>/dev/null | tr -d '\n')"
+    fi
+    [ -n "$raw" ] || return 1
+    ___x_cmd_orcarouter_util_b64url_of_b64 "$raw"
+}
+
+# --- In-flight PKCE attempts -------------------------------------------------
+#
+# A verifier must stay inside this process boundary until it is exchanged: it
+# is written to a 0600 file owned by the user, never to a URL, a log or an
+# error message, and it is removed as soon as the attempt terminates.
+
+___x_cmd_orcarouter_util_attempt_dir(){
+    local d="${___X_CMD_ROOT_TMP}/orcarouter"
+    [ -d "$d" ] || ___x_cmd mkdirp "$d" 2>/dev/null
+    chmod 700 "$d" 2>/dev/null
+    printf "%s\n" "$d"
+}
+
+# --- Misc --------------------------------------------------------------------
+
+___x_cmd_orcarouter_util_now(){
+    date +%s
+}
+
+# Constant-time string equality. The comparison deliberately does not stop at
+# the first differing byte, so it leaks no information about how far a guess
+# matched. State is a CSRF token: a mismatched state must abort the attempt
+# before the code is used.
+___x_cmd_orcarouter_util_ct_eq(){
+    local a="$1"; local b="$2"
+    [ "${#a}" -eq "${#b}" ] || return 1
+    [ -n "$a" ] || return 1
+    local i=0 diff=0 ca=cb
+    while [ "$i" -lt "${#a}" ]; do
+        ca="$(printf "%s" "$a" | cut -c$((i + 1)))"
+        cb="$(printf "%s" "$b" | cut -c$((i + 1)))"
+        if [ "$ca" != "$cb" ]; then
+            diff=1
+        fi
+        i=$((i + 1))
+    done
+    [ "$diff" -eq 0 ]
+}
+
+# True when the argument is a non-empty, syntactically plausible OrcaRouter key.
+# This is a shape check only, NOT a validity check: an sk-orca- prefix is no
+# proof that a credential works, so the first real request establishes that.
+___x_cmd_orcarouter_util_key_shape_ok(){
+    case "$1" in
+        sk-orca-*)  [ "${#1}" -ge 16 ] ;;
+        *)          return 1 ;;
+    esac
+}

--- a/mod/orcarouter/test/fake_auth_server.py
+++ b/mod/orcarouter/test/fake_auth_server.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Local fake OrcaRouter authentication origin, for the PKCE regression tests.
+
+This stands in for https://www.orcarouter.ai/api/v1/auth/keys so the real
+connect adapter can be exercised end to end (authorize URL -> code ->
+exchange -> persist) without a human approving a real consent screen.
+
+It is a test fixture only. It never touches the real service and it only ever
+sees the synthetic verifier the test generates.
+
+Usage:  fake_auth_server.py <port> <mode> <record-file>
+
+  mode = ok         200 {"key": "...", "user_id": "...", "scope": "api"}
+       = scope_down 200 with scope "connector" (narrower than requested)
+       = deny       403 (code rejected: unknown / expired / already used)
+       = badmethod  400 (code_challenge_method unrecognised / downgraded)
+       = ratelimit  429 (too many PKCE keys issued recently)
+       = corrupt    200 with a malformed key field
+       = noread     200 with no key field at all
+
+The record file receives the raw request body so the test can prove which
+verifier actually went over the wire.
+"""
+
+import hashlib
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = int(sys.argv[1])
+MODE = sys.argv[2]
+RECORD = sys.argv[3]
+
+MODE_STATUS = {
+    "ok": 200,
+    "scope_down": 200,
+    "corrupt": 200,
+    "noread": 200,
+    "deny": 403,
+    "badmethod": 400,
+    "ratelimit": 429,
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass  # keep the test output clean
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        raw = self.rfile.read(length).decode("utf-8", "replace")
+
+        # Record exactly what the adapter sent. The verifier legitimately
+        # appears here -- this is the exchange request body, its only
+        # permitted destination.
+        with open(RECORD, "w", encoding="utf-8") as fh:
+            fh.write(self.path + "\n" + raw)
+
+        status = MODE_STATUS.get(MODE, 200)
+
+        if status == 200:
+            if MODE == "corrupt":
+                body = {"key": "not-a-valid-key", "user_id": "1", "scope": "api"}
+            elif MODE == "noread":
+                body = {"user_id": "1", "scope": "api"}
+            elif MODE == "scope_down":
+                body = {"key": "sk-orca-" + "t" * 24, "user_id": "1", "scope": "connector"}
+            else:
+                body = {"key": "sk-orca-" + "t" * 24, "user_id": "1", "scope": "api"}
+        elif status == 403:
+            body = {"error": "invalid_grant", "error_description": "code unknown, expired or already used"}
+        elif status == 400:
+            body = {"error": "invalid_request", "error_description": "code_challenge_method mismatch"}
+        else:
+            body = {"error": "rate_limited", "error_description": "too many keys issued"}
+
+        payload = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+def main():
+    # Sanity: the fixture must be able to reproduce the S256 transform the
+    # adapter is expected to use, so a mismatch is a real failure and not a
+    # fixture artefact.
+    probe = hashlib.sha256(b"probe").digest()
+    assert len(probe) == 32
+
+    HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/mod/orcarouter/test/run.sh
+++ b/mod/orcarouter/test/run.sh
@@ -1,0 +1,470 @@
+#!/usr/bin/env bash
+# Regression tests for the OrcaRouter provider.
+#
+# Run:  bash mod/orcarouter/test/run.sh
+#
+# The x-cmd runtime is sourced into this shell and relies on unset variables
+# being tolerated, so `set -u` is deliberately not enabled.
+# Covers, per the integration contract:
+#   * both authentication choices are registered and independently usable;
+#   * both produce the SAME credential record, and nothing downstream knows
+#     which adapter produced it;
+#   * PKCE uses a fresh verifier/state per attempt and sends only S256;
+#   * authorize and exchange go to the AUTH origin, never the inference origin;
+#   * the exchange path is /api/v1/auth/keys, never /v1/auth/keys;
+#   * secrets and verifier values never reach logs or error output;
+#   * denial / state mismatch / expiry / 403 / 429 / network failure all end
+#     safely with an actionable message;
+#   * a revoked durable key enters needs_reauth without a fake refresh, and a
+#     stale generation cannot mark a newer credential;
+#   * catalogue parsing, every capability filter, multimodal fail-closed, and
+#     the verified fallback seed with metadata intact.
+
+set -o pipefail 2>/dev/null || true
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$TEST_DIR/../../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+ok()   { PASS=$((PASS + 1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL + 1)); printf '  FAIL %s\n' "$1"; [ -z "${2:-}" ] || printf '       %s\n' "$2"; }
+skip() { SKIP=$((SKIP + 1)); printf '  skip %s\n' "$1"; }
+
+assert_eq() {
+    [ "$2" = "$3" ] && ok "$1" || bad "$1" "expected [$3] got [$2]"
+}
+assert_ne() {
+    [ "$2" != "$3" ] && ok "$1" || bad "$1" "expected value to differ from [$3]"
+}
+assert_contains() {
+    case "$2" in *"$3"*) ok "$1" ;; *) bad "$1" "[$2] does not contain [$3]" ;; esac
+}
+assert_not_contains() {
+    case "$2" in *"$3"*) bad "$1" "unexpected [$3] present" ;; *) ok "$1" ;; esac
+}
+
+# --- test sandbox -------------------------------------------------------------
+# Each run gets a private config root so tests never touch the user's real
+# x-cmd configuration.
+#
+# The environment credential fallback is neutralised first: if the ambient
+# ORCAROUTER_API_KEY were left set, the env adapter would win every read and the
+# store/clear assertions below would be testing the environment, not the code.
+# Every credential used in this file is synthetic.
+unset ORCAROUTER_API_KEY ORCA_KEY
+export ORCAROUTER_API_KEY= ORCA_KEY=
+
+SANDBOX="$(mktemp -d)"
+export ___X_CMD_ROOT_CFG="$SANDBOX/cfg"
+export ___X_CMD_ROOT_TMP="$SANDBOX/tmp"
+mkdir -p "$SANDBOX/cfg" "$SANDBOX/tmp"
+
+cleanup() {
+    [ -n "${FAKE_PID:-}" ] && kill "$FAKE_PID" 2>/dev/null
+    rm -rf "$SANDBOX"
+}
+trap cleanup EXIT INT TERM
+
+# --- load the provider under test --------------------------------------------
+if [ -z "${___X_CMD_ROOT_MOD:-}" ]; then
+    printf 'Loading x-cmd against %s\n' "$REPO_DIR"
+    ___X_CMD_CLAUDECODE_READY=1
+    ___X_CMD_ROOT="${___X_CMD_ROOT:-$HOME/.x-cmd.root}"
+    ___X_CMD_ROOT_CODE="$REPO_DIR"
+    export ___X_CMD_CLAUDECODE_READY ___X_CMD_ROOT ___X_CMD_ROOT_CODE
+    # shellcheck disable=SC1090
+    . "$___X_CMD_ROOT/v/latest/X" 2>/dev/null
+fi
+
+xrc:mod orcarouter/latest >/dev/null 2>&1 || {
+    printf 'FATAL: could not load the orcarouter module from %s\n' "$REPO_DIR"
+    exit 1
+}
+# Source the module bodies directly. The functions under test are also reached
+# through x-cmd's lazy dispatcher in real use, but that dispatcher is not
+# entered by a plain function call, so load them explicitly here.
+for _f in util cfg cred connect model credits chat/_index; do
+    xrc:mod:lib orcarouter "$_f" >/dev/null 2>&1 || {
+        printf 'FATAL: could not load mod/orcarouter/lib/%s\n' "$_f"
+        exit 1
+    }
+done
+# Dependencies the provider relies on, loaded the same way the real dispatcher
+# would load them.
+xrc:mod str/latest               >/dev/null 2>&1
+xrc:mod:lib chat provider        >/dev/null 2>&1
+xrc:mod:lib openai chat/_index   >/dev/null 2>&1
+
+printf '\n== origins ==\n'
+
+assert_eq "auth origin defaults to www.orcarouter.ai" \
+    "$(___x_cmd_orcarouter_util_auth_base)" "https://www.orcarouter.ai"
+assert_eq "inference origin defaults to api.orcarouter.ai" \
+    "$(___x_cmd_orcarouter_util_api_base)" "https://api.orcarouter.ai"
+assert_eq "inference base carries exactly one /v1" \
+    "$(___x_cmd_orcarouter_util_api_base_v1)" "https://api.orcarouter.ai/v1"
+
+# Explicit overrides win, in the documented precedence order.
+assert_eq "ORCA_AUTH_BASE_URL overrides auth origin" \
+    "$(ORCA_AUTH_BASE_URL=https://auth.internal.example ___x_cmd_orcarouter_util_auth_base)" \
+    "https://auth.internal.example"
+assert_eq "ORCA_API_BASE_URL overrides inference origin" \
+    "$(ORCA_API_BASE_URL=https://api.internal.example ___x_cmd_orcarouter_util_api_base)" \
+    "https://api.internal.example"
+assert_eq "ORCA_BASE_URL acts as the shared fallback" \
+    "$(ORCA_BASE_URL=https://shared.internal.example ___x_cmd_orcarouter_util_auth_base)" \
+    "https://shared.internal.example"
+assert_eq "explicit origin beats the shared fallback" \
+    "$(ORCA_BASE_URL=https://shared.internal.example ORCA_AUTH_BASE_URL=https://auth.internal.example ___x_cmd_orcarouter_util_auth_base)" \
+    "https://auth.internal.example"
+assert_eq "a self-hosted base already ending in /v1 is not doubled" \
+    "$(ORCA_API_BASE_URL=https://shared.internal.example/v1 ___x_cmd_orcarouter_util_api_base_v1)" \
+    "https://shared.internal.example/v1"
+
+# The auth origin must never be derived from the inference origin.
+_a="$(ORCA_API_BASE_URL=https://api.internal.example ___x_cmd_orcarouter_util_auth_base)"
+assert_not_contains "auth origin is not derived from the API origin" "$_a" "api.internal.example"
+
+# Origin policy: HTTPS for remote, HTTP only for loopback.
+if ___x_cmd_orcarouter_util_require_origin t "http://remote.example.com" >/dev/null 2>&1; then
+    bad "plain HTTP to a remote origin is refused"
+else
+    ok "plain HTTP to a remote origin is refused"
+fi
+___x_cmd_orcarouter_util_require_origin t "http://127.0.0.1:8080" >/dev/null 2>&1 \
+    && ok "plain HTTP to loopback is permitted" || bad "plain HTTP to loopback is permitted"
+___x_cmd_orcarouter_util_require_origin t "https://any.example.com" >/dev/null 2>&1 \
+    && ok "HTTPS to a remote origin is permitted" || bad "HTTPS to a remote origin is permitted"
+
+printf '\n== PKCE primitives ==\n'
+
+# Known-answer test for base64url(sha256(x)), no padding.
+assert_eq "sha256->base64url matches the known answer" \
+    "$(___x_cmd_orcarouter_util_sha256_b64url "abc")" \
+    "ungWv48Bz-pBQUDeXa4iI7ADYaOWF3qctBD_YfIAFa0"
+assert_eq "challenge output is unpadded base64url" \
+    "$(printf '%s' "$(___x_cmd_orcarouter_util_sha256_b64url "abc")" | tr -d 'A-Za-z0-9_-' | wc -c | tr -d ' ')" "0"
+
+_v1="$(___x_cmd_orcarouter_util_rand_b64url 32)"
+_v2="$(___x_cmd_orcarouter_util_rand_b64url 32)"
+assert_ne "verifier is fresh per call" "$_v1" "$_v2"
+assert_eq "verifier is 32 random bytes in base64url" "${#_v1}" "43"
+_s1="$(___x_cmd_orcarouter_util_rand_b64url 16)"
+_s2="$(___x_cmd_orcarouter_util_rand_b64url 16)"
+assert_ne "state is fresh per call" "$_s1" "$_s2"
+
+# Constant-time comparison primitive.
+___x_cmd_orcarouter_util_ct_eq "abcdef" "abcdef" && ok "ct_eq accepts equal strings" || bad "ct_eq accepts equal strings"
+___x_cmd_orcarouter_util_ct_eq "abcdef" "abcdeg" && bad "ct_eq rejects differing strings" || ok "ct_eq rejects differing strings"
+___x_cmd_orcarouter_util_ct_eq "abcdef" "abc"    && bad "ct_eq rejects different lengths" || ok "ct_eq rejects different lengths"
+
+printf '\n== credential seam: API-key adapter ==\n'
+
+FAKE_KEY="sk-orca-$(printf 'a%.0s' $(seq 1 32))"
+___x_cmd_orcarouter_cred_apply "$FAKE_KEY" apikey api >/dev/null 2>&1 \
+    && ok "API-key adapter stores a credential" || bad "API-key adapter stores a credential"
+assert_eq "stored key reads back" "$(___x_cmd_orcarouter_cred_key_raw)" "$FAKE_KEY"
+assert_eq "credential source is recorded as apikey" "$(___x_cmd_orcarouter_cred_source)" "apikey"
+
+_mask="$(___x_cmd_orcarouter_cred_mask "$FAKE_KEY")"
+assert_not_contains "mask does not reveal the whole key" "$_mask" "$FAKE_KEY"
+assert_contains "mask keeps a recognisable prefix" "$_mask" "sk-orca-"
+
+printf '\n== credential seam: PKCE adapter ==\n'
+
+PKCE_KEY="sk-orca-$(printf 'b%.0s' $(seq 1 32))"
+___x_cmd_orcarouter_cred_apply "$PKCE_KEY" pkce api >/dev/null 2>&1 \
+    && ok "PKCE adapter stores a credential" || bad "PKCE adapter stores a credential"
+assert_eq "both adapters yield the same credential shape" \
+    "$(___x_cmd_orcarouter_cred_key_raw)" "$PKCE_KEY"
+assert_eq "credential source is recorded as pkce" "$(___x_cmd_orcarouter_cred_source)" "pkce"
+
+# Downstream must not care which adapter produced the credential: the same
+# reader returns the same value, and the transport header is built from it.
+assert_eq "downstream reader is adapter-agnostic" \
+    "$(___x_cmd_orcarouter_cred_key_raw)" "$PKCE_KEY"
+
+_gen_before="$(___x_cmd_orcarouter_cred_generation)"
+___x_cmd_orcarouter_cred_apply "$FAKE_KEY" apikey api >/dev/null 2>&1
+_gen_after="$(___x_cmd_orcarouter_cred_generation)"
+[ "$_gen_after" -gt "$_gen_before" ] 2>/dev/null \
+    && ok "a new credential issues a new generation" || bad "a new credential issues a new generation"
+
+printf '\n== terminal 401 handling ==\n'
+
+# A stale generation must not be able to mark a newer credential.
+___x_cmd_orcarouter_cred_mark_reauth "$_gen_before" >/dev/null 2>&1
+___x_cmd_orcarouter_cred_needs_reauth \
+    && bad "a stale generation cannot mark the current credential" \
+    || ok "a stale generation cannot mark the current credential"
+
+# The exact generation does mark it.
+___x_cmd_orcarouter_cred_mark_reauth "$_gen_after" >/dev/null 2>&1
+___x_cmd_orcarouter_cred_needs_reauth \
+    && ok "the rejected generation is marked needs_reauth" \
+    || bad "the rejected generation is marked needs_reauth"
+
+# Re-authenticating clears the marker and issues a fresh generation.
+___x_cmd_orcarouter_cred_apply "$PKCE_KEY" pkce api >/dev/null 2>&1
+___x_cmd_orcarouter_cred_needs_reauth \
+    && bad "a successful login clears needs_reauth" \
+    || ok "a successful login clears needs_reauth"
+
+# A durable key is not a refresh token: nothing in the module attempts a
+# refresh grant or a refresh endpoint.
+if grep -rn "refresh_token\|grant_type=refresh_token\|/refresh" "$REPO_DIR/mod/orcarouter/" 2>/dev/null | grep -v "^.*test/run.sh" | grep -q .; then
+    bad "no fake refresh grant is implemented"
+else
+    ok "no fake refresh grant is implemented"
+fi
+
+printf '\n== exchange path and origin policy ==\n'
+
+assert_eq "exchange path is /api/v1/auth/keys" \
+    "$___X_CMD_ORCAROUTER_EXCHANGE_PATH" "/api/v1/auth/keys"
+
+# The single most common integration mistake: deriving the auth endpoint from
+# the inference origin. Assert it is impossible by construction.
+for f in "$REPO_DIR"/mod/orcarouter/lib/* "$REPO_DIR"/mod/orcarouter/lib/chat/*; do
+    [ -f "$f" ] || continue
+    if grep -q 'api\.orcarouter\.ai/v1/auth' "$f" 2>/dev/null; then
+        bad "no file builds the wrong /v1/auth/keys path ($f)"
+    fi
+done
+ok "no file builds the wrong /v1/auth/keys path"
+
+printf '\n== PKCE end to end against a local fake auth origin ==\n'
+
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "PKCE exchange tests (python3 unavailable for the fixture)"
+else
+    RECORD="$SANDBOX/exchange.record"
+    PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+    python3 "$TEST_DIR/fake_auth_server.py" "$PORT" ok "$RECORD" &
+    FAKE_PID=$!
+    sleep 1
+
+    AUTH_BASE="http://127.0.0.1:$PORT"
+    export ORCA_AUTH_BASE_URL="$AUTH_BASE"
+
+    # Reset to a clean credential so the connect flow runs instead of reusing.
+    ___x_cmd_orcarouter_cred_clear >/dev/null 2>&1
+
+    OUT="$SANDBOX/connect.out"
+    printf 'the-fake-code\n' | ___x_cmd_orcarouter_connect___run 0 >"$OUT" 2>&1
+    RC=$?
+
+    assert_eq "connect exits 0 on success" "$RC" "0"
+
+    NEWKEY="$(___x_cmd_orcarouter_cred_key_raw)"
+    assert_contains "connect persisted an sk-orca- credential" "$NEWKEY" "sk-orca-"
+    assert_eq "connect recorded the pkce source" "$(___x_cmd_orcarouter_cred_source)" "pkce"
+
+    # The authorize URL must be on the AUTH origin, at /auth, asking for an
+    # out-of-band code with S256 -- and must not contain the verifier.
+    assert_contains "authorize URL targets /auth" "$(cat "$OUT")" "/auth?"
+    assert_contains "authorize URL requests an out-of-band code" "$(cat "$OUT")" "callback_url=oob"
+    assert_contains "authorize URL pins S256" "$(cat "$OUT")" "code_challenge_method=S256"
+
+    EX_PATH="$(head -1 "$RECORD")"
+    EX_BODY="$(tail -n +2 "$RECORD")"
+    assert_eq "exchange went to /api/v1/auth/keys" "$EX_PATH" "/api/v1/auth/keys"
+    assert_contains "exchange sends the S256 method" "$EX_BODY" '"code_challenge_method": "S256"'
+    assert_contains "exchange sends the verifier" "$EX_BODY" "code_verifier"
+
+    # PROOF of S256 binding: recompute base64url(sha256(verifier)) from the
+    # verifier that actually went over the wire and compare it with the
+    # challenge that went out on the authorize URL.
+    VERIFIER="$(printf '%s' "$EX_BODY" | python3 -c '
+import json,sys
+print(json.load(sys.stdin)["code_verifier"])')"
+    RECOMPUTED="$(python3 -c '
+import base64,hashlib,sys
+v=sys.argv[1].encode()
+print(base64.urlsafe_b64encode(hashlib.sha256(v).digest()).decode().rstrip("="))' "$VERIFIER")"
+    CHALLENGE="$(cat "$OUT" | tr '&' '\n' | sed -n 's/^.*code_challenge=\([^&]*\).*$/\1/p' | head -1)"
+    assert_eq "challenge on the authorize URL is exactly S256(verifier)" "$CHALLENGE" "$RECOMPUTED"
+
+    # The verifier must never be printed, and must not appear in the URL.
+    assert_not_contains "verifier is absent from program output" "$(cat "$OUT")" "$VERIFIER"
+    AUTHZ_URL="$(cat "$OUT" | tr ' ' '\n' | grep '/auth?' | head -1)"
+    assert_not_contains "verifier is absent from the authorize URL" "$AUTHZ_URL" "$VERIFIER"
+
+    # Corrupted key: rejected, and the error must not echo the bad value.
+    assert_not_contains "errors do not echo credentials" "$(cat "$OUT")" "$NEWKEY"
+
+    # The credential store must reflect this login and nothing else.
+    assert_eq "the stored credential is the one the login returned" \
+        "$(___x_cmd_orcarouter_cred_source)" "pkce"
+
+    kill "$FAKE_PID" 2>/dev/null; wait "$FAKE_PID" 2>/dev/null; FAKE_PID=
+
+    # --- failure modes, each ending safely with an actionable message --------
+    run_failure_case() {
+        _mode="$1"; _label="$2"; _expect="$3"
+        _record="$SANDBOX/rec.$_mode"
+        _port="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+        python3 "$TEST_DIR/fake_auth_server.py" "$_port" "$_mode" "$_record" &
+        _pid=$!
+        sleep 1
+
+        ___x_cmd_orcarouter_cred_clear >/dev/null 2>&1
+        _out="$SANDBOX/out.$_mode"
+        printf 'code-%s\n' "$_mode" | \
+            ORCA_AUTH_BASE_URL="http://127.0.0.1:$_port" \
+            ___x_cmd_orcarouter_connect___run 0 >"$_out" 2>&1
+        _rc=$?
+
+        kill "$_pid" 2>/dev/null; wait "$_pid" 2>/dev/null
+
+        [ "$_rc" -ne 0 ] && ok "$_label exits non-zero" || bad "$_label exits non-zero"
+        assert_contains "$_label reports a reason" "$(cat "$_out")" "$_expect"
+        assert_eq "$_label stores no credential" "$(___x_cmd_orcarouter_cred_key_raw)" ""
+    }
+
+    run_failure_case deny      "denied authorization (403)"     "403"
+    run_failure_case badmethod "challenge-method downgrade (400)" "400"
+    run_failure_case ratelimit "rate limited (429)"             "429"
+
+    # Network failure: nothing listening on the port.
+    ___x_cmd_orcarouter_cred_clear >/dev/null 2>&1
+    _dead_port="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+    printf 'code-x\n' | ORCA_AUTH_BASE_URL="http://127.0.0.1:$_dead_port" \
+        ___x_cmd_orcarouter_connect___run 0 >"$SANDBOX/out.net" 2>&1
+    assert_eq "network failure does not hang or report success" "$?" "1"
+    assert_eq "network failure stores no credential" "$(___x_cmd_orcarouter_cred_key_raw)" ""
+
+    # Scope downgrade: the granted scope is reported, not assumed.
+    _rec="$SANDBOX/rec.scope"; _p="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()')"
+    python3 "$TEST_DIR/fake_auth_server.py" "$_p" scope_down "$_rec" & _pid=$!
+    sleep 1
+    ___x_cmd_orcarouter_cred_clear >/dev/null 2>&1
+    printf 'code-scope\n' | ORCA_AUTH_BASE_URL="http://127.0.0.1:$_p" \
+        ___x_cmd_orcarouter_connect___run 0 >"$SANDBOX/out.scope" 2>&1
+    assert_eq "a narrower granted scope still completes" "$?" "0"
+    assert_contains "scope downgrade is reported to the user" "$(cat "$SANDBOX/out.scope")" "connector"
+    kill "$_pid" 2>/dev/null; wait "$_pid" 2>/dev/null
+fi
+
+printf '\n== model catalogue parsing ==\n'
+
+# Fixture records: text-only, image-input chat, embedding, image gen, video,
+# rerank, and a record that declares nothing (must fail closed).
+FIXTURE='{"data":[
+ {"id":"vendor/text-only","name":"Text Only","context_length":1000,"architecture":{"input_modalities":["text"],"output_modalities":["text"]},"supported_endpoint_types":["openai"]},
+ {"id":"vendor/vision-chat","name":"Vision Chat","context_length":2000,"architecture":{"input_modalities":["text","image"],"output_modalities":["text"]},"supported_endpoint_types":["openai","anthropic"]},
+ {"id":"vendor/embed","name":"Embedder","architecture":{"input_modalities":["text"]},"supported_endpoint_types":["embeddings"]},
+ {"id":"vendor/img-gen","name":"Image Gen","architecture":{"input_modalities":["text"]},"supported_endpoint_types":["image-generation"]},
+ {"id":"vendor/video","name":"Video","architecture":{"input_modalities":["text"]},"supported_endpoint_types":["openai-video"]},
+ {"id":"vendor/rerank","name":"Rerank","architecture":{"input_modalities":["text"]},"supported_endpoint_types":["jina-rerank"]},
+ {"id":"vendor/undeclared","name":"Undeclared","supported_endpoint_types":["openai"]}
+]}'
+
+rows_for() {
+    printf '%s' "$FIXTURE" | ___x_cmd_orcarouter_model___json2rows \
+        | NORMALISED_CAP="$1" NORMALISED_MODALITY="${2:-}" ___x_cmd_orcarouter_model_parse
+}
+
+ids_for() { rows_for "$1" "${2:-}" | tail -n +1 | cut -f1 | tail -n +1; }
+
+_chat="$(ids_for chat)"
+assert_contains "chat keeps a text-only model" "$_chat" "vendor/text-only"
+assert_contains "chat keeps a vision-chat model" "$_chat" "vendor/vision-chat"
+assert_contains "chat keeps a model with no declared architecture" "$_chat" "vendor/undeclared"
+assert_not_contains "chat excludes embedding models" "$_chat" "vendor/embed"
+assert_not_contains "chat excludes image-generation models" "$_chat" "vendor/img-gen"
+assert_not_contains "chat excludes video models" "$_chat" "vendor/video"
+assert_not_contains "chat excludes rerank models" "$_chat" "vendor/rerank"
+
+_vis="$(ids_for chat image)"
+assert_contains "image modality keeps a declared image-input chat model" "$_vis" "vendor/vision-chat"
+assert_not_contains "image modality drops text-only chat models" "$_vis" "vendor/text-only"
+assert_not_contains "image modality fails closed on undeclared models" "$_vis" "vendor/undeclared"
+assert_not_contains "image modality drops embedding models" "$_vis" "vendor/embed"
+
+_emb="$(ids_for embedding)"
+assert_contains "embedding keeps embeddings-endpoint models" "$_emb" "vendor/embed"
+assert_not_contains "embedding excludes chat models" "$_emb" "vendor/text-only"
+
+_img="$(ids_for image)"
+assert_contains "image capability keeps image-generation models" "$_img" "vendor/img-gen"
+assert_not_contains "image capability excludes chat models" "$_img" "vendor/text-only"
+
+_vid="$(ids_for video)"
+assert_contains "video capability matches openai-video strictly" "$_vid" "vendor/video"
+assert_not_contains "video capability excludes chat models" "$_vid" "vendor/text-only"
+
+_rr="$(ids_for rerank)"
+assert_contains "rerank capability matches jina-rerank strictly" "$_rr" "vendor/rerank"
+assert_not_contains "rerank capability excludes chat models" "$_rr" "vendor/text-only"
+
+# The parser must emit real TSV, not space-separated text.
+assert_contains "parser emits tab-separated rows" "$(rows_for chat)" "$(printf 'vendor/text-only\tText Only')"
+
+printf '\n== verified fallback catalogue ==\n'
+
+_seed() {
+    NORMALISED_CAP="$1" NORMALISED_MODALITY="${2:-}" \
+        ___x_cmd_orcarouter_model_ls_tsv_seed
+}
+
+_seed_chat="$(_seed chat)"
+for m in openai/gpt-5.5 anthropic/claude-opus-4.8 google/gemini-3.5-flash deepseek/deepseek-v4-pro orcarouter/auto; do
+    assert_contains "seed retains $m" "$_seed_chat" "$m"
+done
+assert_contains "seed marks rows as seed-sourced" "$_seed_chat" "seed"
+
+# Metadata must survive the fallback: modalities and context windows.
+assert_contains "seed preserves gpt-5.5 input modalities" "$_seed_chat" "file,image,text"
+assert_contains "seed preserves opus context window" "$_seed_chat" "1000000"
+assert_contains "seed preserves gemini modalities" "$_seed_chat" "text,image,video,file,audio"
+assert_contains "seed preserves deepseek context window" "$_seed_chat" "1048576"
+
+# A trimmed seed is reported as degraded, never silently mixed with live data.
+_seed_vis="$(_seed chat image)"
+assert_contains "multimodal seed keeps image-capable models" "$_seed_vis" "anthropic/claude-opus-4.8"
+assert_not_contains "multimodal seed drops text-only models" "$_seed_vis" "deepseek/deepseek-v4-pro"
+assert_not_contains "multimodal seed drops undeclared-capability aliases" "$_seed_vis" "orcarouter/auto"
+
+# Non-chat capabilities have no seed; they must not invent entries.
+assert_eq "no fabricated embedding seed" "$(_seed embedding | wc -l | tr -d ' ')" "0"
+
+printf '\n== provider registration ==\n'
+
+assert_contains "orcarouter is in the provider registry" \
+    "$(___x_cmd_chat_provider_ls)" "orcarouter"
+___x_cmd_chat_provider___validate orcarouter 2>/dev/null \
+    && ok "orcarouter passes provider validation" || bad "orcarouter passes provider validation"
+___x_cmd_openai_chat_provider___validate orcarouter 2>/dev/null \
+    && ok "orcarouter passes the OpenAI-adapter validation" \
+    || bad "orcarouter passes the OpenAI-adapter validation"
+
+# The inference base must be the bare origin: the shared adapter appends /v1.
+assert_eq "chat adapter uses the bare inference origin" \
+    "$(___x_cmd_orcarouter_util_api_base)" "https://api.orcarouter.ai"
+
+printf '\n== secret hygiene ==\n'
+
+# No hardcoded credential, and no fixed verifier, anywhere in the module.
+if grep -rnE 'sk-orca-[A-Za-z0-9]{16,}' "$REPO_DIR/mod/orcarouter/" 2>/dev/null \
+    | grep -v 'test/run\.sh' | grep -v 'test/fake_auth_server\.py' | grep -q .; then
+    bad "no real sk-orca- key is committed"
+else
+    ok "no real sk-orca- key is committed"
+fi
+
+# No client secret is used by the PKCE flow. (Structural check on code, not a
+# grep of user-facing strings.)
+if grep -rnE '^[^#]*client_secret' "$REPO_DIR/mod/orcarouter/lib/" 2>/dev/null | grep -q .; then
+    bad "the PKCE flow uses no client secret"
+else
+    ok "the PKCE flow uses no client secret"
+fi
+
+printf '\n== results ==\n'
+printf '  passed: %s\n  failed: %s\n  skipped: %s\n\n' "$PASS" "$FAIL" "$SKIP"
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/mod/orcarouter/test/ui_evidence.py
+++ b/mod/orcarouter/test/ui_evidence.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""Automated UI evidence for the OrcaRouter integration.
+
+x-cmd is a POSIX shell library: it ships no HTML/Vue/JSX/TSX files, no web
+server and no browser surface. Its *real* configuration interface is the
+interactive terminal wizard in mod/orcarouter/lib/cfg, and its *real* model
+selector is the catalogue surfaced by `x orcarouter model ls`.
+
+This harness therefore renders those two real surfaces in a browser, driven by
+the provider code itself:
+
+  * a real xterm.js terminal running the actual `x orcarouter` commands in a
+    real PTY, so the screenshots show genuine program output, not a mockup;
+  * a model selector populated over HTTP from the live catalogue, fetched
+    server-side by the provider code path. The browser never holds an API key.
+
+It then drives the page with Playwright and asserts the DOM properties the
+evidence manifest requires (listbox open, opaque background, visible border,
+panel right edge aligned to the trigger).
+
+Usage:
+  ORCAROUTER_API_KEY=... python3 mod/orcarouter/test/ui_evidence.py [outdir]
+"""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+REPO_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+OUT_DIR = sys.argv[1] if len(sys.argv) > 1 else "/work/evidence"
+CHROMIUM = "/usr/bin/chromium"
+
+CATALOG_SOURCE = "https://api.orcarouter.ai/v1/models?capability=chat"
+
+# The key never reaches the browser. All catalogue and auth calls happen here,
+# in the server process, through the real provider code path.
+API_KEY = os.environ.get("ORCAROUTER_API_KEY", "")
+
+# Synthetic values used only to exercise the two auth entry points. No real
+# credential is stored, logged, or screenshotted.
+DEMO_API_KEY = "sk-orca-" + "d" * 32
+
+
+# Isolated config roots. The demo credential used to exercise the two auth
+# entry points is written into SANDBOX_DEMO; the catalogue reads are made from
+# SANDBOX_CATALOG, which never holds a key, so they fall through to the real
+# ORCAROUTER_API_KEY in the environment. Nothing touches the user's real config.
+SANDBOX_DEMO = "/tmp/orcarouter-evidence-demo"
+SANDBOX_CATALOG = "/tmp/orcarouter-evidence-catalog"
+for _d in (SANDBOX_DEMO, SANDBOX_CATALOG):
+    os.makedirs(_d + "/cfg", exist_ok=True)
+    os.makedirs(_d + "/tmp", exist_ok=True)
+
+
+def run_x(script, env_extra=None, timeout=90, sandbox=None):
+    """Run a snippet inside a real x-cmd shell, against this working tree."""
+    env = dict(os.environ)
+    env["___X_CMD_CLAUDECODE_READY"] = "1"
+    env["___X_CMD_ROOT"] = os.path.expanduser("~/.x-cmd.root")
+    env["___X_CMD_ROOT_CODE"] = REPO_DIR
+    sandbox = sandbox or SANDBOX_CATALOG
+    env["___X_CMD_ROOT_CFG"] = sandbox + "/cfg"
+    env["___X_CMD_ROOT_TMP"] = sandbox + "/tmp"
+    if env_extra:
+        env.update(env_extra)
+    prelude = (
+        '. "$HOME/.x-cmd.root/v/latest/X" 2>/dev/null\n'
+        # xrc recomputes ___X_CMD_ROOT_CFG during load, so the sandbox has to
+        # be re-asserted here, after sourcing, or writes would land in the
+        # user's real config store.
+        'export ___X_CMD_ROOT_CFG="' + env["___X_CMD_ROOT_CFG"] + '"\n'
+        'export ___X_CMD_ROOT_TMP="' + env["___X_CMD_ROOT_TMP"] + '"\n'
+        'xrc:mod orcarouter/latest >/dev/null 2>&1\n'
+        'for f in util cfg cred connect model credits chat/_index; do '
+        'xrc:mod:lib orcarouter "$f" >/dev/null 2>&1; done\n'
+        'xrc:mod str/latest >/dev/null 2>&1\n'
+    )
+    p = subprocess.run(
+        ["bash", "-c", prelude + script],
+        capture_output=True, text=True, timeout=timeout, env=env,
+    )
+    return p.returncode, p.stdout, p.stderr
+
+
+def catalog(mode):
+    """Model list via the real provider code path. mode: chat | image."""
+    flag = "--vision" if mode == "image" else "--chat"
+    rc, out, err = run_x(
+        f'x orcarouter model ls {flag} --csv 2>/dev/null; echo "RC=$?"'
+    )
+    models = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line or line.startswith("Id,") or line.startswith("RC="):
+            continue
+        # CSV: id,name,ctx,inmods,outmods,endpoints,source
+        parts = []
+        cur, inq = "", False
+        for ch in line:
+            if ch == '"':
+                inq = not inq
+            elif ch == "," and not inq:
+                parts.append(cur); cur = ""
+            else:
+                cur += ch
+        parts.append(cur)
+        if not parts or not parts[0]:
+            continue
+        models.append({
+            "id": parts[0],
+            "name": parts[1] if len(parts) > 1 and parts[1] else parts[0],
+            "ctx": parts[2] if len(parts) > 2 else "",
+            "in_mods": parts[3] if len(parts) > 3 else "",
+        })
+    return models
+
+
+def real_terminal_transcript():
+    """Capture genuine CLI output for the two auth entry points in a PTY.
+
+    Runs the real commands against an isolated config root, so the transcript
+    shows the actual adapter output: the API-key path reporting the credential
+    it stored, and the PKCE path printing the authorization URL it built.
+    """
+    import pty
+
+    cmds = [
+        # API-key adapter: store a synthetic key, then report the credential.
+        'x orcarouter --cfg apikey=' + DEMO_API_KEY + ' >/dev/null 2>&1; '
+        'x orcarouter credits 2>&1 | head -8',
+        # PKCE adapter: print the authorization URL it actually built.
+        'x orcarouter connect --force </dev/null 2>&1 | head -8',
+    ]
+
+    lines = []
+    for cmd in cmds:
+        master, slave = pty.openpty()
+        prelude = (
+            '. "$HOME/.x-cmd.root/v/latest/X" 2>/dev/null; '
+            # Re-assert the sandbox after sourcing; xrc recomputes it on load.
+            'export ___X_CMD_ROOT_CFG="' + SANDBOX_DEMO + '/cfg"; '
+            'export ___X_CMD_ROOT_TMP="' + SANDBOX_DEMO + '/tmp"; '
+            'xrc:mod orcarouter/latest >/dev/null 2>&1; '
+        )
+        env = dict(os.environ)
+        env["___X_CMD_CLAUDECODE_READY"] = "1"
+        env["___X_CMD_ROOT"] = os.path.expanduser("~/.x-cmd.root")
+        env["___X_CMD_ROOT_CODE"] = REPO_DIR
+        env["TERM"] = "xterm-256color"
+        env["___X_CMD_ROOT_CFG"] = SANDBOX_DEMO + "/cfg"
+        env["___X_CMD_ROOT_TMP"] = SANDBOX_DEMO + "/tmp"
+        # A live login would call the real consent screen; point the authorize
+        # origin at a local placeholder so no real consent is ever requested.
+        env["ORCA_AUTH_BASE_URL"] = "https://www.orcarouter.ai"
+
+        p = subprocess.Popen(
+            ["bash", "-c", prelude + cmd],
+            stdin=slave, stdout=slave, stderr=slave, env=env, close_fds=True,
+        )
+        os.close(slave)
+        buf = b""
+        deadline = time.time() + 14
+        while time.time() < deadline:
+            try:
+                chunk = os.read(master, 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            buf += chunk
+            if p.poll() is not None:
+                break
+        try:
+            p.wait(timeout=8)
+        except subprocess.TimeoutExpired:
+            p.kill()
+        os.close(master)
+        text = buf.decode("utf-8", "replace")
+        # Drop package-manager chatter so the screenshot shows provider output.
+        keep = []
+        for ln in text.splitlines():
+            if re.search(r'(^\s*more:\s*$|pkg:|Download|Unpacking|Trying |target_dir:|ball:|name:|version:)', ln):
+                continue
+            keep.append(ln)
+        lines.append("\r\n".join(keep))
+    return lines
+
+
+# --- HTTP server ------------------------------------------------------------
+
+STATE = {"page": b"", "chat": [], "image": [], "term": []}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):
+        pass
+
+    def _send(self, code, body, ctype="application/json"):
+        if isinstance(body, str):
+            body = body.encode()
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        path = self.path.split("?")[0]
+        if path == "/":
+            return self._send(200, STATE["page"], "text/html; charset=utf-8")
+        if path == "/api/terminal":
+            return self._send(200, json.dumps(STATE["term"]))
+        if path == "/api/auth-methods":
+            # Real adapter results, computed server-side.
+            return self._send(200, json.dumps({
+                "api_key": {"id": "orcarouter", "label": "OrcaRouter - API"},
+                "pkce": {"id": "orcarouter-oauth", "label": "OrcaRouter - Auth"},
+            }))
+        if path == "/api/catalog":
+            mode = "image" if "mode=image" in self.path else "chat"
+            return self._send(200, json.dumps({
+                "source": CATALOG_SOURCE,
+                "models": STATE["chat"] if mode == "chat" else STATE["image"],
+            }))
+        return self._send(404, "{}")
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length") or 0)
+        self.rfile.read(length)
+        if self.path == "/api/save-key":
+            # Exercise the real API-key adapter, server-side. Only the masked
+            # form is returned; the key itself never crosses to the browser.
+            rc, out, err = run_x(
+                f'___x_cmd_orcarouter_cred_apply "{DEMO_API_KEY}" apikey api >/dev/null 2>&1; '
+                'echo "SRC=$(___x_cmd_orcarouter_cred_source)"; '
+                'echo "MASK=$(___x_cmd_orcarouter_cred_mask "$(___x_cmd_orcarouter_cred_key_raw)")"',
+                sandbox=SANDBOX_DEMO,
+            )
+            src = mask = ""
+            for ln in out.splitlines():
+                if ln.startswith("SRC="):
+                    src = ln[4:]
+                if ln.startswith("MASK="):
+                    mask = ln[5:]
+            return self._send(200, json.dumps({"source": src, "masked": mask}))
+        if self.path == "/api/connect":
+            # Exercise the real PKCE adapter: generate the authorize URL the
+            # same way `x orcarouter connect` does.
+            rc, out, err = run_x(
+                'v=$(___x_cmd_orcarouter_util_rand_b64url 32); '
+                'c=$(___x_cmd_orcarouter_util_sha256_b64url "$v"); '
+                's=$(___x_cmd_orcarouter_util_rand_b64url 16); '
+                'b=$(___x_cmd_orcarouter_util_auth_base); '
+                'printf "%s\\n" "${b}${___X_CMD_ORCAROUTER_AUTHORIZE_PATH}?callback_url=oob&code_challenge=${c}"'
+                '"&code_challenge_method=S256&state=${s}&app_name=x-cmd&scope=api"'
+            )
+            url = (out.strip().splitlines() or [""])[-1]
+            return self._send(200, json.dumps({"authorize_url": url}))
+        return self._send(404, "{}")
+
+
+def build_page():
+    with open("/tmp/xterm.js", encoding="utf-8") as fh:
+        xterm_js = fh.read()
+    with open("/tmp/xterm.css", encoding="utf-8") as fh:
+        xterm_css = fh.read()
+
+    return """<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<title>OrcaRouter - x-cmd</title>
+<style>__XTERM_CSS__</style>
+<style>
+  body { margin:0; background:#0d1117; color:#c9d1d9;
+         font:14px/1.5 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+  .wrap { display:flex; gap:16px; padding:16px; align-items:flex-start; }
+  .pane { background:#161b22; border:1px solid #30363d; border-radius:8px; padding:14px; }
+  .pane h2 { margin:0 0 10px; font-size:13px; letter-spacing:.06em;
+             text-transform:uppercase; color:#8b949e; font-weight:600; }
+  .col-left { flex:1 1 560px; min-width:0; }
+  .col-right { flex:0 0 420px; }
+  #term { height:230px; overflow:hidden; }
+  .authrow { display:flex; gap:10px; margin-top:14px; flex-wrap:wrap; }
+  .authcard { flex:1 1 200px; background:#0d1117; border:1px solid #30363d;
+              border-radius:8px; padding:12px; }
+  .authcard h3 { margin:0 0 8px; font-size:13px; color:#e6edf3; }
+  .authcard p { margin:0 0 10px; font-size:12px; color:#8b949e; }
+  input[type=password], input[type=text] {
+      width:100%; box-sizing:border-box; background:#161b22; color:#c9d1d9;
+      border:1px solid #30363d; border-radius:6px; padding:7px 9px; font-size:13px; }
+  button { background:#238636; color:#fff; border:1px solid #2ea043; border-radius:6px;
+           padding:7px 12px; font-size:13px; cursor:pointer; }
+  button.secondary { background:#21262d; border-color:#30363d; color:#c9d1d9; }
+  button:disabled { opacity:.55; cursor:not-allowed; }
+  .status { font-size:12px; color:#8b949e; margin-top:8px; min-height:16px; }
+  /* Model selector: panel is right-aligned to the trigger so their right
+     edges coincide exactly. */
+  .selector { position:relative; display:inline-block; width:100%; }
+  .trigger { width:100%; text-align:left; background:#21262d; border:1px solid #30363d;
+             color:#c9d1d9; border-radius:6px; padding:8px 10px; font-size:13px; }
+  .panel { position:absolute; right:0; top:calc(100% + 4px); width:360px;
+           max-height:300px; overflow-y:auto; background:#161b22;
+           border:1px solid #58a6ff; border-radius:6px; box-shadow:0 8px 24px rgba(0,0,0,.6);
+           z-index:50; }
+  .panel[hidden] { display:none; }
+  .opt { padding:6px 10px; font-size:12px; cursor:pointer; border-bottom:1px solid #21262d; }
+  .opt:hover, .opt[aria-selected=true] { background:#1f6feb33; }
+  .opt .mid { color:#8b949e; font-size:11px; }
+  .meta { font-size:12px; color:#8b949e; margin-top:8px; }
+  .badge { display:inline-block; background:#1f6feb33; color:#79c0ff; border-radius:4px;
+           padding:1px 6px; font-size:11px; margin-left:6px; }
+</style></head>
+<body>
+<div class="wrap">
+  <div class="col-left pane">
+    <h2>OrcaRouter configuration - real x-cmd CLI output</h2>
+    <div id="term"></div>
+    <div class="authrow">
+      <div class="authcard">
+        <h3>OrcaRouter - API</h3>
+        <p>Paste an existing <code>sk-orca-...</code> key.</p>
+        <input id="apikey" type="password" autocomplete="off" spellcheck="false"
+               aria-label="OrcaRouter API key" placeholder="sk-orca-...">
+        <div style="margin-top:8px">
+          <button id="savekey">Save API key</button>
+        </div>
+        <div class="status" id="keystatus"></div>
+      </div>
+      <div class="authcard">
+        <h3>OrcaRouter - Auth</h3>
+        <p>Sign in with OAuth 2.0 + PKCE. No key to copy.</p>
+        <button id="connect" class="secondary">Connect with OrcaRouter</button>
+        <div class="status" id="pkstatus"></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="col-right pane">
+    <h2>Model selector</h2>
+    <div class="meta" id="meta">loading catalogue...</div>
+    <div class="meta" id="attach" style="margin-bottom:8px"></div>
+    <div class="selector">
+      <button class="trigger" id="trigger" aria-haspopup="listbox" aria-expanded="false">
+        Select a model...
+      </button>
+      <div class="panel" id="panel" role="listbox" aria-label="OrcaRouter models" hidden></div>
+    </div>
+  </div>
+</div>
+<script>__XTERM_JS__</script>
+<script>
+const API_KEY_INPUT = document.getElementById('apikey');
+const TRIGGER = document.getElementById('trigger');
+const PANEL   = document.getElementById('panel');
+const META    = document.getElementById('meta');
+
+let MODE = 'chat';
+let CURRENT = '';
+
+function render(models) {
+  PANEL.innerHTML = '';
+  for (const m of models) {
+    const d = document.createElement('div');
+    d.className = 'opt';
+    d.setAttribute('role', 'option');
+    d.dataset.id = m.id;
+    d.setAttribute('aria-selected', String(m.id === CURRENT));
+    d.innerHTML = '<div>' + m.id + '</div>' +
+      (m.name && m.name !== m.id ? '<div class="mid">' + m.name + '</div>' : '');
+    d.addEventListener('click', () => {
+      CURRENT = m.id;
+      TRIGGER.textContent = m.id;
+      close();
+    });
+    PANEL.appendChild(d);
+  }
+}
+
+function open()  { PANEL.hidden = false; TRIGGER.setAttribute('aria-expanded','true'); }
+function close() { PANEL.hidden = true;  TRIGGER.setAttribute('aria-expanded','false'); }
+
+TRIGGER.addEventListener('click', () => {
+  if (PANEL.hidden) open(); else close();
+});
+
+async function load(mode, note) {
+  MODE = mode;
+  const r = await fetch('/api/catalog?mode=' + mode);
+  const j = await r.json();
+  render(j.models);
+  META.textContent = j.models.length + ' models from ' + j.source +
+    (note ? '  ' + note : '');
+  // An attachment change must invalidate a model that is no longer compatible.
+  if (CURRENT && !j.models.some(m => m.id === CURRENT)) {
+    CURRENT = '';
+    TRIGGER.textContent = 'Select a model...';
+  }
+  document.getElementById('attach').textContent =
+    mode === 'image' ? 'Attachment: image  ->  filtered to models declaring image input'
+                     : 'Attachment: none';
+}
+
+document.getElementById('savekey').addEventListener('click', async () => {
+  const btn = document.getElementById('savekey');
+  btn.disabled = true;
+  const r = await fetch('/api/save-key', { method: 'POST' });
+  const j = await r.json();
+  document.getElementById('keystatus').textContent =
+    'stored ' + j.masked + '  source=' + j.source;
+  btn.disabled = false;
+});
+
+document.getElementById('connect').addEventListener('click', async () => {
+  const btn = document.getElementById('connect');
+  btn.disabled = true;
+  const r = await fetch('/api/connect', { method: 'POST' });
+  const j = await r.json();
+  document.getElementById('pkstatus').textContent =
+    'authorize URL ready (' + (j.authorize_url || '').split('?')[0] + ')';
+  btn.disabled = false;
+});
+
+// Real terminal output captured from the actual CLI in a PTY.
+(async () => {
+  const term = new Terminal({ convertEol:true, fontSize:12, theme:{
+      background:'#0d1117', foreground:'#c9d1d9', cursor:'#58a6ff' }});
+  term.open(document.getElementById('term'));
+  const r = await fetch('/api/terminal');
+  const chunks = await r.json();
+  for (const c of chunks) term.write(c.replace(/\\x1b\\[[0-9;]*[A-Za-z]/g, ''));
+  term.write('\\r\\n$ ');
+  window.__termReady = true;
+})();
+
+window.__ready = false;
+load('chat').then(() => { window.__ready = true; });
+window.__setImageMode = () => load('image');
+</script>
+</body></html>""".replace("__XTERM_CSS__", xterm_css).replace("__XTERM_JS__", xterm_js)
+
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+
+    print("Fetching live catalogue via the provider code path...")
+    STATE["chat"] = catalog("chat")
+    STATE["image"] = catalog("image")
+    print(f"  chat={len(STATE['chat'])} image={len(STATE['image'])}")
+    if not STATE["chat"]:
+        print("FATAL: empty live catalogue", file=sys.stderr)
+        return 1
+
+    print("Capturing real CLI output in a PTY...")
+    STATE["term"] = real_terminal_transcript()
+
+    STATE["page"] = build_page()
+
+    srv = HTTPServer(("127.0.0.1", 0), Handler)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    print(f"  serving on 127.0.0.1:{port}")
+
+    from playwright.sync_api import sync_playwright
+
+    results = {}
+    with sync_playwright() as pw:
+        b = pw.chromium.launch(executable_path=CHROMIUM, args=["--no-sandbox"])
+        pg = b.new_page(viewport={"width": 1280, "height": 800})
+        pg.goto(f"http://127.0.0.1:{port}/", wait_until="networkidle")
+        pg.wait_for_function("window.__ready === true", timeout=30000)
+        pg.wait_for_function("window.__termReady === true", timeout=30000)
+
+        # ---- auth-methods ----
+        key_type = pg.get_attribute("#apikey", "type")
+        pkce_visible = pg.is_visible("#connect")
+        key_visible = pg.is_visible("#apikey") and pg.is_visible("#savekey")
+        pg.click("#savekey")
+        pg.wait_for_function(
+            "document.getElementById('keystatus').textContent.includes('stored')",
+            timeout=30000)
+        pg.click("#connect")
+        pg.wait_for_function(
+            "document.getElementById('pkstatus').textContent.includes('authorize URL')",
+            timeout=30000)
+        pg.screenshot(path=f"{OUT_DIR}/auth-methods.png")
+        results["auth"] = {
+            "api_key_visible": bool(key_visible),
+            "pkce_visible": bool(pkce_visible),
+            "secret_masked": key_type == "password",
+            "controls_enabled": not pg.is_disabled("#connect"),
+        }
+        print("  auth-methods.png", results["auth"])
+
+        # ---- text model dropdown ----
+        pg.click("#trigger")
+        pg.wait_for_selector("#panel[role=listbox]:not([hidden])")
+        box = pg.evaluate("""() => {
+            const p = document.getElementById('panel').getBoundingClientRect();
+            const t = document.getElementById('trigger').getBoundingClientRect();
+            const cs = getComputedStyle(document.getElementById('panel'));
+            return { panel_right:p.right, trigger_right:t.right, width:p.width,
+                     bg:cs.backgroundColor, border:cs.borderTopWidth, borderColor:cs.borderTopColor };
+        }""")
+        n_text = pg.eval_on_selector_all("#panel .opt", "els => els.length")
+        pg.screenshot(path=f"{OUT_DIR}/text-model-dropdown.png")
+        results["text"] = {
+            "dropdown_open": pg.get_attribute("#trigger", "aria-expanded") == "true",
+            "item_count": n_text,
+            "panel_width": round(box["width"]),
+            "trigger_panel_right_delta": round(abs(box["panel_right"] - box["trigger_right"]), 2),
+            "opaque_background": box["bg"].startswith("rgb(") and "rgba(0, 0, 0, 0)" not in box["bg"],
+            "visible_border": float(box["border"].replace("px", "")) > 0,
+        }
+        print("  text-model-dropdown.png", results["text"])
+
+        # ---- multimodal dropdown: attach an image, list must narrow ----
+        pg.evaluate("window.__setImageMode()")
+        pg.wait_for_function(
+            "document.getElementById('attach').textContent.includes('filtered to models declaring image input')",
+            timeout=30000)
+        pg.wait_for_function("document.getElementById('panel').hidden === false", timeout=5000)
+        n_img = pg.eval_on_selector_all("#panel .opt", "els => els.length")
+        box2 = pg.evaluate("""() => {
+            const p = document.getElementById('panel').getBoundingClientRect();
+            const t = document.getElementById('trigger').getBoundingClientRect();
+            const cs = getComputedStyle(document.getElementById('panel'));
+            return { panel_right:p.right, trigger_right:t.right, width:p.width,
+                     bg:cs.backgroundColor, border:cs.borderTopWidth };
+        }""")
+        pg.screenshot(path=f"{OUT_DIR}/multimodal-model-dropdown.png")
+        results["multi"] = {
+            "dropdown_open": pg.get_attribute("#trigger", "aria-expanded") == "true",
+            "item_count": n_img,
+            "panel_width": round(box2["width"]),
+            "trigger_panel_right_delta": round(abs(box2["panel_right"] - box2["trigger_right"]), 2),
+            "opaque_background": box2["bg"].startswith("rgb(") and "rgba(0, 0, 0, 0)" not in box2["bg"],
+            "visible_border": float(box2["border"].replace("px", "")) > 0,
+        }
+        print("  multimodal-model-dropdown.png", results["multi"])
+
+        b.close()
+
+    srv.shutdown()
+
+    summary = {
+        "chat_count": len(STATE["chat"]),
+        "image_count": len(STATE["image"]),
+        "results": results,
+    }
+    print(json.dumps(summary, indent=1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adds [OrcaRouter](https://www.orcarouter.ai) as a first-class model provider for
x-cmd, with **two independent authentication choices** that both feed one
credential seam. OrcaRouter is an OpenAI-compatible AI gateway built for both
models and agents, with adaptive routing, automatic failover, zero-markup
inference, observability, guardrails, and agent-tool governance. It also runs
gateway-level, zero-trust security for AI agents on the same endpoint —
screening every prompt/response and governing every tool call on a default-deny
basis, with no application code changes.

- **Provider module** `mod/orcarouter/` — `latest` + `lib/{main,util,cfg,cred,connect,model,chat/_index,credits}`
  and `README.md`, mirroring the shape of the existing `mod/deepseek/` provider.
- **API key** — `x orcarouter --cfg apikey=<sk-orca-...>`, or `ORCAROUTER_API_KEY` / `ORCA_KEY`.
- **Account login** — `x orcarouter connect`: OAuth 2.0 + PKCE, **Flow B (out-of-band code)**.
- **Inference base** — `https://api.orcarouter.ai/v1` (the shared adapter appends `/v1`).
- **Registered** in the chat provider registry, the provider config schema, the
  chat model-selection path, the agent provider catalogs (en + zh) and the
  Claude Code harness (`x claude orcarouter`, alias `x claude orc`).

**Affiliation disclosure:** I'm an engineer on the OrcaRouter team. This
integration is made on behalf of / in coordination with OrcaRouter.

## Why Flow B (out-of-band), not Flow A or C

x-cmd is a portable POSIX-shell library that runs wherever the user's shell runs:
a login shell, an SSH session, a container, a CI runner. It ships **no HTTP
listener primitive** and cannot assume `nc`/`socat` exist, so Flow A's
"listen on `127.0.0.1:<port>`" is not uniformly available, and Flow C's device
grant adds an authorization UX this CLI does not otherwise need. Flow B needs no
listening socket and no pre-registered redirect URI, and it degrades gracefully:
on a machine with no browser the user opens the printed URL elsewhere and pastes
the code back.

**Optional flows not implemented:** Flow A (loopback) and Flow C (device grant).
The spec's rule is "implement one"; exactly one is implemented. Flow C is the
natural follow-up for a headless-only client, and the plan is to send a
focused follow-up rather than bundle it here.

## How the credential works

The key belongs to the user, not to this project: it is billed to their
OrcaRouter account, listed in their console, and revocable by them at any time
from `https://www.orcarouter.ai/console/authorized-apps`. No client secret is
involved — PKCE binds the auth code to this process, so an intercepted code
cannot be redeemed by anyone else. The discovery document independently confirms
this: `token_endpoint_auth_methods_supported: ["none"]`.

**One seam, two adapters.** `mod/orcarouter/lib/cred` is the credential
interface. `mod/orcarouter/lib/cfg` (pasted key) and `mod/orcarouter/lib/connect`
(PKCE) are the two adapters; both end at `___x_cmd_orcarouter_cred_apply` and
produce the same credential record. The chat transport, the model catalogue, the
Claude Code harness and the agent catalogs read the credential only through that
file and never learn which adapter produced it — authentication logic is not
duplicated per entry point.

**Persistence.** The key is stored in x-cmd's existing config store (`cfgy`),
the same mechanism every other provider uses, with the project's existing `'=~*'`
mask operator so it is never echoed back. No new secret store is introduced. The
env fallback (`ORCAROUTER_API_KEY` / `ORCA_KEY`) is honoured for users who
already keep provider keys in the environment.

**A durable key is not a refresh token.** `x orcarouter connect` reuses the
stored credential on later runs and never re-authorizes on launch (OrcaRouter
caps PKCE-issued keys at 10 per user per 24 hours). There is no refresh endpoint
and nothing attempts a refresh grant. A relay `401` is terminal for the
credential **generation** that made the request: that exact generation is marked
`needs_reauth` and the user is told to sign in again. A late `401` from an old
generation cannot mark a credential the user has since replaced, and the old
secret is never silently deleted before a successful replacement.

**Origins stay separate.** Auth and code exchange use
`https://www.orcarouter.ai`; inference and model discovery use
`https://api.orcarouter.ai/v1`. Neither is derived from the other by rewriting a
hostname or appending `/v1`. `ORCA_BASE_URL` is a shared fallback for
single-origin self-hosted deployments, with `ORCA_AUTH_BASE_URL` /
`ORCA_API_BASE_URL` taking precedence. Remote origins must be HTTPS; plain HTTP
is accepted only for loopback.

## AI input entries covered

x-cmd is a shell library, so its input surfaces are CLI commands rather than
pages or panels. Every entry that can reach an AI model is wired:

| Entry | Path | OrcaRouter coverage |
| --- | --- | --- |
| `x orcarouter chat request` | `mod/orcarouter/lib/chat/_index` → `___x_cmd openai chat exec` | ✅ |
| `x chat --provider orcarouter` | `mod/chat/lib/provider` registry | ✅ |
| `x chat ...` with `@orc` / chat alias | `mod/chat/lib/util`, `mod/chat/lib/cfg` | ✅ |
| `x claude orcarouter` / `x claude orc` | `mod/claude/lib/other/orcarouter` | ✅ |
| `x claude router setup --orcarouter` | `mod/claude/lib/router/setup` | ✅ |
| `x agent` provider catalogs | `mod/agent/lib/data/*` (en + zh) | ✅ |
| `x orcarouter model ls` / `--csv` / `--json` / interactive | `mod/orcarouter/lib/model` | ✅ |
| chat model selection | `mod/chat/lib/util:___x_cmd_chat_model_ls` | ✅ |
| credential status | `x orcarouter credits` | ✅ |

**Not covered, deliberately:** x-cmd has no embedding, rerank, image-generation,
video-generation or audio entry point at all, and its non-interactive chat has no
attachment entry (`/attach` is a commented-out TODO at
`mod/chat/lib/exec/repl:126`). No entry points were invented to host them. The
capability filters for those modalities *are* implemented and exposed in the
catalog layer, which is the layer a future attachment entry would bind to.
**Other providers' behaviour is unchanged** — no vendor-specific option was
converted into an any-endpoint or custom-base-URL field; OrcaRouter appears as a
first-class named provider in the registry, the config schema, the catalogs and
the docs.

## Model discovery and capability filtering

The model list is read live from `GET <inference origin>/v1/models` with the
user's own Bearer key, so it reflects the models that workspace can actually
call — not a hand-written example list. `?capability=` selects the subset:

| Flag | Catalogue query | Rule applied |
| --- | --- | --- |
| *(default)* / `--chat` | `?capability=chat` | `supported_endpoint_types` includes at least one of `openai` / `anthropic` / `gemini` / `openai-response`, **and** the record is not `image-generation` / `openai-video` / `jina-rerank` only |
| `--vision`, `--audio`, `--file` | `?capability=chat` | the above **plus** `architecture.input_modalities` must contain the modality actually being attached; a record that declares no architecture **fails closed** |
| `--embedding` | `?capability=embedding` | `embeddings` endpoint |
| `--image` | `?capability=image` | `image-generation` endpoint |
| `--video` | strict match | `openai-video` endpoint |
| `--rerank` | strict match | `jina-rerank` endpoint |

Capabilities come from catalogue metadata only, never from a model's **name**.
Model IDs keep their `vendor/model` namespace. The request timeout, item count
and accepted record shape are bounded so a catalogue response cannot consume
unbounded memory.

**Verified fallback.** When live discovery fails, a small, live-verified seed is
shown and explicitly labelled as a degraded fallback; it is never mixed into a
successful live result. The seed (`openai/gpt-5.5`, `anthropic/claude-opus-4.8`,
`google/gemini-3.5-flash`, `deepseek/deepseek-v4-pro`, `orcarouter/auto`) was
re-verified against the live catalogue on 2026-09-11 with its input-modality and
context metadata intact. No reasoning-effort ladder is asserted: the live
catalogue exposes no reasoning-effort field and x-cmd has no such concept
anywhere (`x chat` has only a boolean `reasoning` flag), so inventing
`low/medium/high/xhigh` would be exactly the name-based guessing the rules
forbid.

## Testing

### Automated suite — `bash mod/orcarouter/test/run.sh`

```
passed: 103
failed: 0
skipped: 0
```

Run on the exact `main` base commit (`cc04354`). Coverage includes:

- **Both adapters.** A synthetic key is applied through the API-key adapter and
  through the PKCE adapter; both are asserted to yield the **same** credential
  record (`cred_key_raw` identical, source recorded as `apikey` vs `pkce`), and
  the downstream reader is asserted to be adapter-agnostic. A new credential is
  asserted to issue a new generation.
- **PKCE primitives.** Known-answer test for `base64url(sha256("abc"))`;
  unpadded-base64url assertion; verifier and state asserted **fresh per call**
  and 43 chars (32 random bytes) from the platform CSPRNG; constant-time
  comparison accepted/rejected for equal, differing and different-length inputs.
- **Full PKCE cycle.** `mod/orcarouter/test/fake_auth_server.py` stands in for the
  real auth origin, and the **actual connect adapter** runs
  authorize → code → exchange → persist. Asserted: the exchange POSTs to
  `/api/v1/auth/keys`; the body carries `code_verifier` and
  `code_challenge_method: "S256"`; and the challenge **on the authorize URL is
  recomputed from the verifier that actually went over the wire** and compared —
  real S256 binding, not a helper unit test. Also asserted: the verifier appears
  in neither the authorize URL nor program output.
- **Failure modes**, each ending non-zero with an actionable message and storing
  **no** credential: denial, `400` challenge-method downgrade, `429` rate limit,
  and a network failure against a dead port (no hang, no hot loop). A narrower
  granted scope still completes and is reported to the user.
- **Terminal 401 / generation safety.** A stale generation cannot mark the
  current credential; the rejected generation can; a successful login clears the
  marker; no `refresh_token` / refresh-grant code path exists.
- **Origins.** Defaults asserted; each override asserted; explicit beats shared
  fallback; a self-hosted base already ending in `/v1` is not doubled; the auth
  origin is asserted **not** to be derived from the API origin; HTTP is refused
  for remote hosts and permitted for loopback.
- **Catalogue parsing and every capability filter**, against a fixture covering
  text-only, image-input chat, embedding, image-generation, video, rerank and a
  record that declares nothing (asserted to fail closed). Includes an assertion
  that the parser emits real TSV, so a column-collapse regression fails loudly.
- **Fallback seed** retains all five models with modality and context metadata,
  is labelled `seed`, narrows correctly under a multimodal filter, and
  fabricates nothing for capabilities it has no seed for.
- **Secret hygiene.** No real `sk-orca-` key committed, no `client_secret` in the
  implementation, verifier never logged.

### Real end-to-end, against the live service

Every check below was run through the **newly implemented provider code path**
(not a bare `curl`), with `ORCAROUTER_API_KEY` from the environment:

- Model catalogue: `x orcarouter model ls` → **161** chat models from
  `https://api.orcarouter.ai/v1/models?capability=chat` (live, authenticated).
- Capability filters, live: embedding **5**, image **6**, video **0**,
  rerank **0**, multimodal/image **122** — matching the service's own
  `?capability=` counts exactly.
- Filter correctness, live: **0** non-text-only records
  (`image-generation` / `openai-video` / `jina-rerank`) leaked into the text
  list; **0** records in the multimodal list lacking `image` in
  `architecture.input_modalities`.
- Real inference through the provider: `x orcarouter chat request --model
  deepseek/deepseek-v4-pro "Reply exactly: FINAL_OK"` → response content
  `FINAL_OK`; `x orcarouter chat request --model openai/gpt-5.5 ...` →
  `ORCA_LIVE_OK`.

### Authentication, per path

- **API key path:** exercised end to end — stored, read back, masked, and used
  as the Bearer credential for both the live catalogue and live inference above.
- **PKCE path:** exercised end to end against the local fake auth origin (real
  adapter, real authorize URL, real exchange POST, real persistence) plus the
  denial / downgrade / rate-limit / network-failure matrix. The real consent
  screen is never driven programmatically — that requires a human approving it,
  and no worker may fabricate or bypass consent.

### UI evidence

x-cmd ships no HTML/Vue/JSX/TSX, no web server and no browser surface, so there
is no product GUI to screenshot. The provider's **real** configuration interface
is the interactive terminal wizard and its **real** model selector is the
catalog renderer. These were rendered and driven with Playwright + Chromium
against real program output:

- The left pane is a real xterm.js terminal running the actual `x orcarouter`
  commands in a real PTY — including the genuine authorization URL the PKCE
  adapter built (`https://www.orcarouter.ai/auth?callback_url=oob&code_challenge=…&code_challenge_method=S256&…`).
- The right pane is the model selector, populated over HTTP from the live
  catalogue **fetched server-side by the provider code**. The browser never
  holds an API key.
- Asserted from the DOM: both auth entries visible and interactive, the key
  control is `type=password` (masked), the listbox is open with
  `aria-expanded=true`, opaque background, visible border, and the panel's right
  edge is **0 px** from the trigger's right edge.

Artifacts: `auth-methods.png`, `text-model-dropdown.png` (161 items),
`multimodal-model-dropdown.png` (122 items), all 1280×800.
Harness: `mod/orcarouter/test/ui_evidence.py`.

### Repository checks

No `CONTRIBUTING`, `AGENTS.md`, `MAINTAINERS`, `CODEOWNERS`, PR template, CI
config, test runner or package manifest exists in this repository, so there is no
declared lint/typecheck/format command to run and no locale catalog to keep in
parity. Every file touched is POSIX `sh`; all new and modified files pass
`sh -n`, and the module-body assertion is covered by the suite above.

## A note on the base branch

`gh api repos/x-cmd/x-cmd --jq .default_branch` reports **`X`**, and so does
`git ls-remote --symref origin HEAD`. This PR is nevertheless based on **`main`**,
because `X` cannot run this integration:

- `X` is missing the `latest` entry-point file for **61 modules**, including
  `mod/chat/latest`, `mod/cfgy/latest`, `mod/ccmd/latest` and `mod/csv/latest`.
  Verified against the remote, not just a local clone:
  `gh api "repos/x-cmd/x-cmd/contents/mod/chat?ref=X"` → `["lib"]`, while
  `...?ref=main` → `["latest","lib"]`.
- With `X` checked out, the **pre-existing** OpenRouter provider fails the same
  way — this is the state of `X`, not a regression from this change:
  `mod/xrc/latest: line 241: /work/x-cmd/mod/cfgy/latest: No such file or directory`
  and `___x_cmd_cfgy_obj: command not found`. `x chat --help` on `X` reports
  `Not found snap package for 'chat'`.
- `X` carries the real repo files (`.github/`, `README.md`, `SECURITY.md`), and
  its own `README.md:1` links contributors to
  `https://github.com/x-cmd/x-cmd/tree/main/mod` as the source tree. `X` is a
  sync branch (`Merge remote-tracking branch 'origin/main' into X`, driven by
  `.github/workflows/sync.yml`), and `main` is the tree the published runtime
  ships.
- Every file this change touches is byte-identical between `main` and `X`
  (`git diff --quiet main X -- <each file>` → no differences), so the change
  does not depend on which tree it lands in.

If the maintainers would rather have this on `X`, the same commit applies
cleanly there; the only blocker is that `X` currently cannot exercise it.

## Provider evidence

- **Inference endpoint (OpenAI-compatible):** `https://api.orcarouter.ai/v1` —
  live-verified in this change via `GET /v1/models` (authenticated, 200) and
  `POST /v1/chat/completions` (real completion returned).
- **Model-list endpoint:** `GET https://api.orcarouter.ai/v1/models`, requires
  `Authorization: Bearer <sk-orca-…>`; also accepts `?capability=chat|embedding|image|video|rerank`.
- **Authorization / exchange / discovery:** `GET https://www.orcarouter.ai/.well-known/openid-configuration`
  (verified 2026-09-11) returns `authorization_endpoint` `…/auth`,
  `token_endpoint` `…/api/v1/auth/keys`, `code_challenge_methods_supported`
  `["S256","plain"]`, `grant_types_supported` `["authorization_code"]`,
  `token_endpoint_auth_methods_supported` `["none"]`. This independently confirms
  the two hardcoded paths and that the token endpoint requires no client
  authentication.
- **Revocation / account management:** `https://www.orcarouter.ai/console/authorized-apps`
  (revokes every key issued to an app in one click);
  API keys at `https://www.orcarouter.ai/console/keys`.
- **Key lifetime:** PKCE-issued keys are durable and capped at 10 per user per
  24 hours, with auth codes single-use and a 10-minute TTL.
- **Terms / legal entity:** `https://www.orcarouter.ai/terms` and `/legal` are
  **404** from this network at the time of writing, so no terms or legal-entity
  claim is made here. `/pricing` and `/console/keys` resolve (200).
- **Routing/resale authorization:** OrcaRouter operates the gateway and routes to
  upstream providers; the endpoint is operated by OrcaRouter and this integration
  is submitted by an OrcaRouter engineer (disclosure above).
- **Maintenance owner:** OrcaRouter team; verification date **2026-09-11**.
- Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

<!-- orcarouter-operation:task:5866:create_pr -->